### PR TITLE
Switch fr.openfisca.org to HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,21 @@ For more information on `auto-update` sub-directories, please see their own READ
 
 ## Server configuration
 
-The nginx modules are controlled by directives specified in configuration files.
-In our case, these configuration files are stored in a directory named after the configured domain name.  
-For example: `www.openfisca.fr`'s configuration file is `openfisca-ops/www.openfisca.fr/www.openfisca.fr.conf`
+The nginx configuration files are loaded from the `/etc/nginx/sites-available` directory.
+In order to keep these files versionned, we use symlinks from this directory towards the server local clone of this repository.
+
+When you edit one of these files, run this command afterwards so that your changes are taken into account:
+```sh
+service nginx reload
+```
 
 ## Services
 
-We use [systemd](https://wiki.debian.org/systemd) services to ensure the continued operation of the OpenFisca related applications (OpenFisca-France [web](https://api.openfisca.fr/) [APIs](https://api-test.openfisca.fr/), [legislation explorer](https://legislation.openfisca.fr/)). `systemd` is available on most recent (> 2015) linux distributions.
+We use [systemd](https://wiki.debian.org/systemd) services to ensure the continued operation of the OpenFisca related applications (OpenFisca-France [web API](https://fr.openfisca.org/api/v2), [legislation explorer](https://legislation.openfisca.fr/)). `systemd` is available on most recent (> 2015) linux distributions.
 
-The service configuration files are loaded from the `/etc/systemd/system` directory. Symlinks pointing to the source code directory can be used.
+The service configuration files are loaded from the `/etc/systemd/system` directory.
+In order to keep these files versionned, we use symlinks from this directory towards the server local clone of this repository.
+
 
 When you edit one of these files, run this command afterwards so that your changes are taken into account:
 ```sh

--- a/README.md
+++ b/README.md
@@ -32,10 +32,15 @@ When you edit one of these files, run this command afterwards so that your chang
 systemctl daemon-reload
 ```
 
+
+## Set up a SSL certificate
+
+See the [dedicated page](guides/Set-up-SSL.md).
+
 ## Renew SSL certificates
 
-To renew the SSL certificate of an OpenFisca related application, run in `root` the following command, replacing `api-test.openfisca.fr` by the domain that needs a certificate update:
+To renew the SSL certificate of an OpenFisca related application, run in `root` the following command, replacing `fr.openfisca.org` by the domain that needs a certificate update:
 ```sh
-certbot certonly --webroot -w /tmp/renew-webroot/ -d api-test.openfisca.fr
+certbot certonly --webroot -w /tmp/renew-webroot/ -d fr.openfisca.org
 service nginx reload
 ```

--- a/fr.openfisca.org/fr.openfisca.org.conf
+++ b/fr.openfisca.org/fr.openfisca.org.conf
@@ -1,27 +1,14 @@
 server {
-    listen 80;
-    server_name fr.openfisca.org;
+        listen 80;
+        server_name fr.openfisca.org;
 
-    access_log /var/log/nginx/fr.openfisca.org-access.log;
-    error_log /var/log/nginx/fr.openfisca.org-error.log;
+        location /.well-known {
+            root /tmp/renew-webroot;
+        }
 
-    location /.well-known {
-        root /tmp/renew-webroot;
-    }
-
-    location /api/v2 {
-        proxy_pass http://localhost:6000/;
-        proxy_set_header Host $http_host;
-        proxy_http_version 1.1;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    }
-
-    location / {
-        proxy_pass http://localhost:2010;
-        proxy_set_header Host $http_host;
-        proxy_http_version 1.1;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    }
+        location / {
+                return 301 https://$server_name$request_uri;
+        }
 }
 
 server {

--- a/fr.openfisca.org/fr.openfisca.org.conf
+++ b/fr.openfisca.org/fr.openfisca.org.conf
@@ -1,25 +1,50 @@
 server {
-	listen 80;
-	server_name fr.openfisca.org;
+    listen 80;
+    server_name fr.openfisca.org;
 
-	access_log /var/log/nginx/fr.openfisca.org-access.log;
-	error_log /var/log/nginx/fr.openfisca.org-error.log;
+    access_log /var/log/nginx/fr.openfisca.org-access.log;
+    error_log /var/log/nginx/fr.openfisca.org-error.log;
 
-	location /.well-known {
-		root /tmp/renew-webroot;
-	}
+    location /.well-known {
+        root /tmp/renew-webroot;
+    }
 
-	location /api/v2 {
-		proxy_pass http://localhost:6000/;
-		proxy_set_header Host $http_host;
-		proxy_http_version 1.1;
-		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-	}
+    location /api/v2 {
+        proxy_pass http://localhost:6000/;
+        proxy_set_header Host $http_host;
+        proxy_http_version 1.1;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
 
-	location / {
-		proxy_pass http://localhost:2010;
-		proxy_set_header Host $http_host;
-		proxy_http_version 1.1;
-		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-	}
+    location / {
+        proxy_pass http://localhost:2010;
+        proxy_set_header Host $http_host;
+        proxy_http_version 1.1;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+}
+
+server {
+        listen 443 ssl;
+        server_name fr.openfisca.org;
+
+        ssl_certificate /etc/letsencrypt/live/fr.openfisca.org/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/fr.openfisca.org/privkey.pem;
+
+        access_log /var/log/nginx/fr.openfisca.org-access.log;
+        error_log /var/log/nginx/fr.openfisca.org-error.log;
+
+    location /api/v2 {
+        proxy_pass http://localhost:6000/;
+        proxy_set_header Host $http_host;
+        proxy_http_version 1.1;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    location / {
+        proxy_pass http://localhost:2010;
+        proxy_set_header Host $http_host;
+        proxy_http_version 1.1;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
 }

--- a/guides/Set-up-SSL.md
+++ b/guides/Set-up-SSL.md
@@ -1,0 +1,70 @@
+# Set up HTTPS on a domain name
+
+To handle `HTTPS` on a website, we need an up-to-date SSL **certificate**. For `openfisca.fr` and `openfisca.org`, we use [Let’s Encrypt](https://letsencrypt.org/) as a certificate provider.
+
+Note that we need one certificate per subdomain:
+- `openfisca.org` and `fr.openfisca.org` use **two different** certificates.
+- `fr.openfisca.org` and `fr.openfisca.org/api/` use **the same** certificate, even if they are different applications.
+
+The following instructions will help you set up a SSL certificate, taking `fr.openfisca.org` as an example.
+
+## 1. Expose `./well-known` in HTTP
+
+To get our certificate from Let's Encrypt, we need to prove that we are indeed the owner of `fr.openfisca.org`. To do so, we need to expose the content of a static directory in **HTTP**. This is done by [adding these lines](https://github.com/openfisca/openfisca-ops/blob/4524f707ab1123258621d2e16dc0df20a9140e73/fr.openfisca.org/fr.openfisca.org.conf#L5-L7) in the NGINX configuration :
+
+```
+location /.well-known {
+    root /tmp/renew-webroot;
+}
+```
+
+## 2. Get the certificate
+
+To get the certificate, run :
+
+```sh
+certbot certonly --webroot -w /tmp/renew-webroot/ -d fr.openfisca.org
+```
+
+If this suceeds, certificates are generated in the `/etc/letsencrypt/live/fr.openfisca.org/` directory.
+
+## 3. Set SSL in NGINX
+
+To allow HTTPS for a domain name, [edit the NGINX configuration](https://github.com/openfisca/openfisca-ops/blob/4524f707ab1123258621d2e16dc0df20a9140e73/fr.openfisca.org/fr.openfisca.org.conf#L14-L19) file to reference the generated certificate:
+
+```
+server {
+        listen 443 ssl;
+        server_name fr.openfisca.org;
+
+        ssl_certificate /etc/letsencrypt/live/fr.openfisca.org/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/fr.openfisca.org/privkey.pem;
+
+    location / {
+        ...
+    }
+
+} 
+```
+
+Then run `service nginx reload` to take your changes into account.
+
+At this point, `https://fr.openfisca.org` should work! Make sure it does before going further.
+
+> To do so, just type https://fr.openfisca.org in your browser, without forgetting the **s** at the end of **https**, and check that the page loads without any certificate error.
+
+## 4. Redirect HTTP traffic to HTTPS
+
+If you are **serving an API**, be careful. This is a breaking change: if some users are using your API in HTTP, and haven't set up their client to follow `301` redirections, their code will break.
+
+Make sure to give enough time to your users to adapt before enforcing HTTPS, and of course, make sure to update the common OpenFisca tools that consume the API.
+
+If you are just serving a website, the redirection should be transparent for users.
+
+To enforce HTTPS, just [add these lines](https://github.com/openfisca/openfisca-ops/blob/4524f707ab1123258621d2e16dc0df20a9140e73/fr.openfisca.org/fr.openfisca.org.conf#L9-L11) to your **HTTP** configuration in the NGINX configuration file:
+
+```
+location / {
+        return 301 https://$server_name$request_uri;
+}
+```


### PR DESCRIPTION
Connected to openfisca/openfisca-core#572

Depends on https://github.com/openfisca/legislation-explorer/pull/122

Partially in prod : [https](https://fr.openfisca.org/api/v2/parameters) works but [http](http://fr.openfisca.org/api/v2/parameters) doesn't redirect towards HTTPS yet.