### PR TITLE
Add fr.openfisca.org/api/v18 to serve the official url  API

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ service nginx reload
 
 ## Services
 
-We use [systemd](https://wiki.debian.org/systemd) services to ensure the continued operation of the OpenFisca related applications (OpenFisca-France [web API](https://fr.openfisca.org/api/v2), [legislation explorer](https://legislation.openfisca.fr/)). `systemd` is available on most recent (> 2015) linux distributions.
+We use [systemd](https://wiki.debian.org/systemd) services to ensure the continued operation of the OpenFisca related applications (OpenFisca-France [web API](https://fr.openfisca.org/api/v18), [legislation explorer](https://legislation.openfisca.fr/)). `systemd` is available on most recent (> 2015) linux distributions.
 
 The service configuration files are loaded from the `/etc/systemd/system` directory.
 In order to keep these files versionned, we use symlinks from this directory towards the server local clone of this repository.

--- a/api-test.openfisca.fr/api-test.openfisca.fr.conf
+++ b/api-test.openfisca.fr/api-test.openfisca.fr.conf
@@ -7,7 +7,7 @@ server {
 	}
 
 	location / {
-		return 302 http://fr.openfisca.org/api/v2$request_uri;
+		return 302 http://fr.openfisca.org/api/v18$request_uri;
 	}
 }
 
@@ -22,7 +22,7 @@ server {
 	error_log /var/log/nginx/api-test.openfisca.fr-error.log;
 
 	location / {
-		return 302 http://fr.openfisca.org/api/v2$request_uri;
+		return 302 http://fr.openfisca.org/api/v18$request_uri;
 	}
 }
 

--- a/fr.openfisca.org/api/openfisca-web-api-new.service
+++ b/fr.openfisca.org/api/openfisca-web-api-new.service
@@ -3,7 +3,7 @@ Description=OpenFisca Web API - New
 
 [Service]
 Environment=COUNTRY_PACKAGE=openfisca_france
-Environment=SERVER_NAME=fr.openfisca.org/api/v2
+Environment=SERVER_NAME=fr.openfisca.org/api/v18
 Environment=TRACKER_URL=https://stats.data.gouv.fr/piwik.php
 Environment=TRACKER_IDSITE=4
 ExecStart=/home/openfisca/virtualenvs/new-api/bin/gunicorn "openfisca_web_api_preview.app:create_app()" --workers 3 --bind localhost:6000

--- a/fr.openfisca.org/fr.openfisca.org.conf
+++ b/fr.openfisca.org/fr.openfisca.org.conf
@@ -28,6 +28,13 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 
+    location /api/v18 {
+        proxy_pass http://localhost:6000/;
+        proxy_set_header Host $http_host;
+        proxy_http_version 1.1;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
     location / {
         proxy_pass http://localhost:2010;
         proxy_set_header Host $http_host;

--- a/fr.openfisca.org/fr.openfisca.org.conf
+++ b/fr.openfisca.org/fr.openfisca.org.conf
@@ -32,6 +32,7 @@ server {
         proxy_pass http://localhost:6000/;
         proxy_set_header Host $http_host;
         proxy_http_version 1.1;
+        # This line is here only to insure retro-compatibility
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 

--- a/fr.openfisca.org/fr.openfisca.org.conf
+++ b/fr.openfisca.org/fr.openfisca.org.conf
@@ -22,7 +22,8 @@ server {
         error_log /var/log/nginx/fr.openfisca.org-error.log;
 
     location /api/v2 {
-        # Deprecated url versioning shema
+
+        # Deprecated url versioning shema. This ensures retro-compatibility with deprecated url schema
         proxy_pass http://localhost:6000/;
         proxy_set_header Host $http_host;
         proxy_http_version 1.1;
@@ -34,7 +35,6 @@ server {
         proxy_pass http://localhost:6000/;
         proxy_set_header Host $http_host;
         proxy_http_version 1.1;
-        # This line is here only to insure retro-compatibility with api/v2
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 

--- a/fr.openfisca.org/fr.openfisca.org.conf
+++ b/fr.openfisca.org/fr.openfisca.org.conf
@@ -22,6 +22,7 @@ server {
         error_log /var/log/nginx/fr.openfisca.org-error.log;
 
     location /api/v2 {
+        # Deprecated url versioning shema
         proxy_pass http://localhost:6000/;
         proxy_set_header Host $http_host;
         proxy_http_version 1.1;
@@ -29,10 +30,11 @@ server {
     }
 
     location /api/v18 {
+        # new url versioning shema
         proxy_pass http://localhost:6000/;
         proxy_set_header Host $http_host;
         proxy_http_version 1.1;
-        # This line is here only to insure retro-compatibility
+        # This line is here only to insure retro-compatibility with api/v2
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 


### PR DESCRIPTION
Connected to openfisca/openfisca-core#570
This PR changes the server configuration to serve the new API on fr.openfisca.org/api/v18.
API version # should be increase at each Openfisca-France major version bump.
