### PR TITLE
Redirect old url to new url schema

### DIFF
--- a/fr.openfisca.org/fr.openfisca.org.conf
+++ b/fr.openfisca.org/fr.openfisca.org.conf
@@ -24,10 +24,7 @@ server {
     location /api/v2 {
 
         # Deprecated url versioning shema. This ensures retro-compatibility with deprecated url schema
-        proxy_pass http://localhost:6000/;
-        proxy_set_header Host $http_host;
-        proxy_http_version 1.1;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        rewrite ^\/api\/v2(.*) /api/v18$1 redirect;
     }
 
     location /api/v18 {


### PR DESCRIPTION
Connected to openfisca/openfisca-core#570
Redirect the old api/V2 url to the api/V18 url schema.