### PR TITLE
Update required OpenFisca-France version

### DIFF
--- a/auto-update-pip-packages/requirements.txt
+++ b/auto-update-pip-packages/requirements.txt
@@ -1,2 +1,2 @@
-OpenFisca-France[api] >= 18.0.0, < 19.0
+OpenFisca-France[api] >= 19.0.0rc0, < 20.0
 OpenFisca-Tracker == 0.1.0


### PR DESCRIPTION
Connected to openfisca/openfisca-france#831

This PR updates the openfisca-france version required by Travis CI when deploying the old API.

