### PR TITLE
Deploy new fr.openfisca.org website

### DIFF
--- a/fr.openfisca.org/fr.openfisca.org.conf
+++ b/fr.openfisca.org/fr.openfisca.org.conf
@@ -52,16 +52,16 @@ server {
         rewrite ^\/api\/v2(.*) /api/v18$1 redirect;
     }
 
-    location /beta/ {
-	rewrite ^/beta/(/.*)$ $1 break;
-        proxy_pass http://localhost:2011/;
+    location /zeta/ {
+        rewrite ^/zeta/(/.*)$ $1 break;
+        proxy_pass http://localhost:2010;
         proxy_set_header Host $http_host;
         proxy_http_version 1.1;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 
     location / {
-        proxy_pass http://localhost:2010;
+        proxy_pass http://localhost:2011/;
         proxy_set_header Host $http_host;
         proxy_http_version 1.1;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/fr.openfisca.org/fr.openfisca.org.conf
+++ b/fr.openfisca.org/fr.openfisca.org.conf
@@ -52,14 +52,6 @@ server {
         rewrite ^\/api\/v2(.*) /api/v18$1 redirect;
     }
 
-    location /zeta/ {
-        rewrite ^/zeta/(/.*)$ $1 break;
-        proxy_pass http://localhost:2010;
-        proxy_set_header Host $http_host;
-        proxy_http_version 1.1;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    }
-
     location / {
         proxy_pass http://localhost:2011/;
         proxy_set_header Host $http_host;

--- a/fr.openfisca.org/website/deploy.sh
+++ b/fr.openfisca.org/website/deploy.sh
@@ -2,8 +2,8 @@
 
 set -ex
 
-yarn install
-yarn build
+npm install
+npm run build
 
 # The current user must have been specifically allowed to run the next command
 # Use the visudo command to do so

--- a/fr.openfisca.org/website/fr.openfisca.org-beta.service
+++ b/fr.openfisca.org/website/fr.openfisca.org-beta.service
@@ -4,7 +4,7 @@ Description=OpenFisca-France website
 [Service]
 EnvironmentFile=/home/openfisca/secret/piwik_token
 Environment=SERVER_NAME=fr.openfisca.org/beta
-ExecStart=/usr/bin/yarn --cwd /home/openfisca/fr.openfisca.org/ start -p 2011
+ExecStart=/usr/local/bin/npm start --prefix /home/openfisca/fr.openfisca.org/ -- -p 2011
 User=openfisca
 Restart=always
 


### PR DESCRIPTION
Fixes openfisca/fr.openfisca.org#2

Remove old website from nginx configuration
Move new website from `fr.openfisca.org/beta` to `fr.openfisca.org`
Run new website systems service and deploy with `npm`