### PR TITLE
Redirect openfisca.fr to new website

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ### 0.5.0 [#33](https://github.com/openfisca/openfisca-ops/pull/33)
 
 - Redirect traffic from openfisca.fr to fr.openfisca.org's new website
+
 On repo :
 - modified openfisca-ops/www.openfisca.fr/www.openfisca.fr.conf
+
 On server :
 - Replaced file home/openfisca/production-configs/www.openfisca.fr/config/www.openfisca.fr.conf with symlink to /home/openfisca/openfisca-ops/www.openfisca.fr/www.openfisca.fr.conf

--- a/www.openfisca.fr/CHANGELOG.md
+++ b/www.openfisca.fr/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+### 0.5.0 [#33](https://github.com/openfisca/openfisca-ops/pull/33)
+
+- Redirect traffic from openfisca.fr to fr.openfisca.org's new website
+On repo :
+- modified openfisca-ops/www.openfisca.fr/www.openfisca.fr.conf
+On server :
+- Replaced file home/openfisca/production-configs/www.openfisca.fr/config/www.openfisca.fr.conf with symlink to /home/openfisca/openfisca-ops/www.openfisca.fr/www.openfisca.fr.conf

--- a/www.openfisca.fr/www.openfisca.fr.conf
+++ b/www.openfisca.fr/www.openfisca.fr.conf
@@ -43,21 +43,7 @@ server {
 	ssl_certificate /etc/letsencrypt/live/www.openfisca.fr-0001/fullchain.pem;
 	ssl_certificate_key /etc/letsencrypt/live/www.openfisca.fr-0001/privkey.pem;
 
-	access_log /var/log/nginx/www.openfisca.fr-access.log;
-	error_log /var/log/nginx/www.openfisca.fr-error.log;
-
 	location / {
-		proxy_pass http://localhost:2010;
-		proxy_set_header Host $http_host;
-		proxy_http_version 1.1;
-		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-	}
-
-	location /robots.txt {
-		alias /home/openfisca/production-configs/www.openfisca.fr/static/robots.txt;
-	}
-
-	location /stats {
-		alias /var/cache/munin/www;
+		return 301 https://fr.openfisca.org$request_uri;
 	}
 }


### PR DESCRIPTION
Connected to #13 

- Add CHANGELOG
- Redirect traffic from openfisca.fr to fr.openfisca.org's new website
On repo :
- modified openfisca-ops/www.openfisca.fr/www.openfisca.fr.conf
On server :
- Replaced file home/openfisca/production-configs/www.openfisca.fr/config/www.openfisca.fr.conf with symlink to /home/openfisca/openfisca-ops/www.openfisca.fr/www.openfisca.fr.conf