### PR TITLE
Add fr.openfisca.org/legislation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+### 0.6.0 [#33](https://github.com/openfisca/openfisca-ops/pull/33)
+
+- Host the legislation explorer on fr.openfisca.org/legislation
+
+On repo :
+- In order to redirect traffic : modified openfisca-ops/fr.openfisca.org/fr.openfisca.org.conf
+- In order to have the service for the legislation explorer on openfisca-ops : created openfisca-ops/fr.openfisca.org/legislation-explorer/legislation-explorer.service
+
+On server :
+- created symlink legislation-explorer.service to home/openfisca/openfisca-ops/fr.openfisca.org/legislation-explorer/legislation-explorer.service
+
 ### 0.5.0 [#33](https://github.com/openfisca/openfisca-ops/pull/33)
 
 - Redirect traffic from openfisca.fr to fr.openfisca.org's new website

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### 0.6.0 [#33](https://github.com/openfisca/openfisca-ops/pull/33)
+### 0.6.0 [#40](https://github.com/openfisca/openfisca-ops/pull/40)
 
 - Host the legislation explorer on fr.openfisca.org/legislation
 

--- a/fr.openfisca.org/fr.openfisca.org.conf
+++ b/fr.openfisca.org/fr.openfisca.org.conf
@@ -1,26 +1,29 @@
-server {
-        listen 80;
-        server_name fr.openfisca.org;
-
-        location /.well-known {
-            root /tmp/renew-webroot;
-        }
-
-        location / {
-                return 301 https://$server_name$request_uri;
-        }
+upstream legislation-explorer {
+    server localhost:2030;
 }
 
 server {
-        listen 443 ssl;
-        server_name fr.openfisca.org;
+    listen 80;
+    server_name fr.openfisca.org;
 
-        ssl_certificate /etc/letsencrypt/live/fr.openfisca.org/fullchain.pem;
-        ssl_certificate_key /etc/letsencrypt/live/fr.openfisca.org/privkey.pem;
+    location /.well-known {
+        root /tmp/renew-webroot;
+    }
 
-        access_log /var/log/nginx/fr.openfisca.org-access.log;
-        error_log /var/log/nginx/fr.openfisca.org-error.log;
+    location / {
+        return 301 https://$server_name$request_uri;
+    }
+}
 
+server {
+    listen 443 ssl;
+    server_name fr.openfisca.org;
+
+    ssl_certificate /etc/letsencrypt/live/fr.openfisca.org/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/fr.openfisca.org/privkey.pem;
+
+    access_log /var/log/nginx/fr.openfisca.org-access.log;
+    error_log /var/log/nginx/fr.openfisca.org-error.log;
 
     location /api/v18 {
         # new url versioning shema
@@ -31,7 +34,7 @@ server {
     }
 
     location /api/v19 {
-        # new url versioning shema
+        # New url versioning shema
         proxy_pass http://localhost:8019/;
         proxy_set_header Host $http_host;
         proxy_http_version 1.1;
@@ -47,9 +50,15 @@ server {
     }
 
     location /api/v2 {
-
         # Deprecated url versioning shema. This ensures retro-compatibility with deprecated url schema
         rewrite ^\/api\/v2(.*) /api/v18$1 redirect;
+    }
+
+    location ~/legislation(.*)$ {
+        proxy_pass http://legislation-explorer$1;
+        proxy_set_header Host $http_host;
+        proxy_http_version 1.1;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 
     location / {

--- a/fr.openfisca.org/legislation-explorer/legislation-explorer.service
+++ b/fr.openfisca.org/legislation-explorer/legislation-explorer.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=OpenFisca Legislation Explorer
+
+[Service]
+Environment=NODE_ENV=production
+Environment=BASENAME=/legislation
+ExecStart=/usr/bin/node /home/openfisca/legislation-explorer/index.js
+User=openfisca
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Connected to openfisca/openfisca-ops#13

- [x] Add a catch all proxy_pass, to avoid React's history router for non-root URIs.
- [x] Add fr.openfisca.org/legislation service