### PR TITLE
Redirect old legislation-explorer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,33 @@
 # Changelog
 
-### 0.6.0 [#40](https://github.com/openfisca/openfisca-ops/pull/40)
+### 0.7.0 [#41](https://github.com/openfisca/openfisca-ops/pull/41)
 
-- Host the legislation explorer on fr.openfisca.org/legislation
+- Redirect traffic from `legislation.openfisca.fr` to `fr.openfisca.org/legislation`.
 
 On repo :
-- In order to redirect traffic : modified openfisca-ops/fr.openfisca.org/fr.openfisca.org.conf
-- In order to have the service for the legislation explorer on openfisca-ops : created openfisca-ops/fr.openfisca.org/legislation-explorer/legislation-explorer.service
+- In order to have the configuration `legislation.openfisca.fr` on `openfisca-ops` : created `openfisca-ops/legislation.openfisca.fr/legislation.openfisca.conf with the redirection.
 
 On server :
-- created symlink legislation-explorer.service to home/openfisca/openfisca-ops/fr.openfisca.org/legislation-explorer/legislation-explorer.service
+- Replaced symlink `for nginx/sites-available/legislation.openfisca.fr.conf`to file `openfisca-ops/legislation.openfisca.fr/legislation.openfisca.conf`.
+
+
+### 0.6.0 [#40](https://github.com/openfisca/openfisca-ops/pull/40)
+
+- Host the legislation explorer on `fr.openfisca.org/legislation`
+
+On repo :
+- In order to redirect traffic : modified `openfisca-ops/fr.openfisca.org/fr.openfisca.org.conf`.
+- In order to have the service for the legislation explorer on `openfisca-ops` : created `openfisca-ops/fr.openfisca.org/legislation-explorer/legislation-explorer.service`.
+
+On server :
+- created symlink `legislation-explorer.service` to `home/openfisca/openfisca-ops/fr.openfisca.org/legislation-explorer/legislation-explorer.service`.
 
 ### 0.5.0 [#33](https://github.com/openfisca/openfisca-ops/pull/33)
 
-- Redirect traffic from openfisca.fr to fr.openfisca.org's new website
+- Redirect traffic from `openfisca.fr` to `fr.openfisca.org`'s new website.
 
 On repo :
-- modified openfisca-ops/www.openfisca.fr/www.openfisca.fr.conf
+- modified `openfisca-ops/www.openfisca.fr/www.openfisca.fr.conf`.
 
 On server :
-- Replaced file home/openfisca/production-configs/www.openfisca.fr/config/www.openfisca.fr.conf with symlink to /home/openfisca/openfisca-ops/www.openfisca.fr/www.openfisca.fr.conf
+- Replaced file `home/openfisca/production-configs/www.openfisca.fr/config/www.openfisca.fr.conf with symlink to `/home/openfisca/openfisca-ops/www.openfisca.fr/www.openfisca.fr.conf`.

--- a/legislation.openfisca.fr/legislation.openfisca.fr.conf
+++ b/legislation.openfisca.fr/legislation.openfisca.fr.conf
@@ -7,7 +7,7 @@ server {
         }
 
         location / {
-                return 301 https://$server_name$request_uri;
+                return 301 https://fr.openfisca.org/legislation$request_uri;
         }
 }
 

--- a/legislation.openfisca.fr/legislation.openfisca.fr.conf
+++ b/legislation.openfisca.fr/legislation.openfisca.fr.conf
@@ -1,0 +1,27 @@
+server {
+        listen 80;
+        server_name legislation.openfisca.fr;
+
+        location /.well-known {
+            root /tmp/renew-webroot;
+        }
+
+        location / {
+                return 301 https://$server_name$request_uri;
+        }
+}
+
+server {
+        listen 443 ssl;
+        server_name legislation.openfisca.fr;
+
+        ssl_certificate /etc/letsencrypt/live/legislation.openfisca.fr/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/legislation.openfisca.fr/privkey.pem;
+
+        access_log /var/log/nginx/legislation.openfisca.fr-access.log;
+        error_log /var/log/nginx/legislation.openfisca.fr-error.log;
+
+        location / {
+                return 301 https://fr.openfisca.org/legislation$request_uri;
+        }
+}


### PR DESCRIPTION
Fixes #35 
connected to openfisca/openfisca-ops#13

- Redirect traffic from `legislation.openfisca.fr` to `fr.openfisca.org/legislation`.

On repo :
- In order to have the configuration `legislation.openfisca.fr` on `openfisca-ops` : created `openfisca-ops/legislation.openfisca.fr/legislation.openfisca.conf with the redirection.

On server :
- Replaced symlink `for nginx/sites-available/legislation.openfisca.fr.conf`to file `openfisca-ops/legislation.openfisca.fr/legislation.openfisca.conf`.

