### PR TITLE
Forward scheme to Flask apps

### DIFF
--- a/demo.openfisca.org/demo.openfisca.org.conf
+++ b/demo.openfisca.org/demo.openfisca.org.conf
@@ -16,7 +16,7 @@ server {
 }
 
 server {
-    listen 443;
+    listen 443 ssl;
     server_name demo.openfisca.org;
 
     ssl_certificate /etc/letsencrypt/live/demo.openfisca.org/fullchain.pem;
@@ -30,6 +30,7 @@ server {
         proxy_set_header Host $http_host/api;
         proxy_http_version 1.1;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 
     location ~/legislation(.*)$ {

--- a/demo.openfisca.org/legislation-explorer/.env
+++ b/demo.openfisca.org/legislation-explorer/.env
@@ -4,7 +4,7 @@ HOST=0.0.0.0
 PORT=9030
 PATHNAME=/legislation
 
-API_URL=http://demo.openfisca.org/api
+API_URL=https://demo.openfisca.org/api
 CHANGELOG_URL=https://github.com/openfisca/country-template/blob/master/CHANGELOG.md
 
 UI_STRINGS={"en":{"countryName":"Demo", "search_placeholder": "tax, salary"},"fr":{"countryName":"Demo", "search_placeholder": "tax, salary"}}

--- a/fr.openfisca.org/fr.openfisca.org.conf
+++ b/fr.openfisca.org/fr.openfisca.org.conf
@@ -30,6 +30,7 @@ server {
         proxy_set_header Host $http_host/api/v21;
         proxy_http_version 1.1;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 
     location /api/v24 {
@@ -37,6 +38,7 @@ server {
         proxy_set_header Host $http_host/api/v24;
         proxy_http_version 1.1;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 
     set $served_versions '


### PR DESCRIPTION
As the APIs are behind a reverse proxy, they don't know we are using HTTPS unless we specify the `X-Forwarded-Proto` header!

Thanks @maukoquiroga for the work of migrating to HTTPS!