### PR TITLE
Enable Matomo in production

### DIFF
--- a/fr.openfisca.org/legislation-explorer/legislation-explorer.service
+++ b/fr.openfisca.org/legislation-explorer/legislation-explorer.service
@@ -2,6 +2,8 @@
 Description=OpenFisca Legislation Explorer
 
 [Service]
+Environment=MATOMO_URL=https://stats.data.gouv.fr
+Environment=MATOMO_SITE_ID=4
 ExecStart=/usr/local/bin/npm start --prefix /home/openfisca/legislation-explorer
 User=openfisca
 Restart=always


### PR DESCRIPTION
Enable Matomo for https://fr.openfisca.org/legislation/ - complements similar issues raised by @renardpal for other openfisca.org assets.

I don't know how to test this other than by deploying to the live prod.