### PR TITLE
Fix latest France web api to respect setup dependencies

### DIFF
--- a/fr.openfisca.org/api/latest/deploy.sh
+++ b/fr.openfisca.org/api/latest/deploy.sh
@@ -5,7 +5,7 @@ set -ex
 REQUIREMENTS="/home/openfisca/openfisca-ops/fr.openfisca.org/api/latest/requirements.txt"
 
 source /home/openfisca/virtualenvs/api-fr-latest/bin/activate
-pip install --requirement "$REQUIREMENTS" --upgrade --upgrade-strategy eager
+pip install --requirement "$REQUIREMENTS"
 # The current user must have been specifically allowed to run the next command
 # Use the visudo command to do so
 sudo systemctl restart openfisca-web-api-fr-latest.service


### PR DESCRIPTION
Delete upgrade eager install for latest api

Before:
This [requirements.txt](https://github.com/openfisca/openfisca-ops/blob/ffd0f2ece4ec709dbc9fb91fe3126855a1e91d48/fr.openfisca.org/api/latest/requirements.txt) with this [--upgrade](https://github.com/openfisca/openfisca-ops/blob/ffd0f2ece4ec709dbc9fb91fe3126855a1e91d48/fr.openfisca.org/api/latest/deploy.sh#L8) option at installation upgraded Core version even when it was incompatible with France latest merged version.