### PR TITLE
Also serve our content at api.fr.openfisca.org

### DIFF
--- a/fr.openfisca.org/fr.openfisca.org.conf
+++ b/fr.openfisca.org/fr.openfisca.org.conf
@@ -4,7 +4,7 @@ upstream legislation-explorer {
 
 server {
     listen 80;
-    server_name fr.openfisca.org;
+    server_name fr.openfisca.org api.fr.openfisca.org;
 
     location /.well-known {
         root /tmp/renew-webroot;


### PR DESCRIPTION
This is a temporary name, so that we can use fr.openfisca.org for the new setup of the content site on Netlify, and still serve the API by redirecting (on Netlify) fr.openfisca.org/api to api.fr.openfisca.org.