### PR TITLE
Ensure compatibility france core for /latest 

### DIFF
--- a/fr.openfisca.org/api/latest/deploy.sh
+++ b/fr.openfisca.org/api/latest/deploy.sh
@@ -2,10 +2,12 @@
 
 set -ex
 
-REQUIREMENTS="/home/openfisca/openfisca-ops/fr.openfisca.org/api/latest/requirements.txt"
-
 source /home/openfisca/virtualenvs/api-fr-latest/bin/activate
-pip install --requirement "$REQUIREMENTS" --upgrade --upgrade-strategy eager
+
+pip install "OpenFisca-Core[web-api]" --upgrade --upgrade-strategy eager
+pip install "OpenFisca-France" --upgrade --upgrade-strategy eager
+pip install "OpenFisca-Tracker == 0.4.0"
+
 # The current user must have been specifically allowed to run the next command
 # Use the visudo command to do so
 sudo systemctl restart openfisca-web-api-fr-latest.service

--- a/fr.openfisca.org/api/latest/requirements.txt
+++ b/fr.openfisca.org/api/latest/requirements.txt
@@ -1,3 +1,0 @@
-OpenFisca-Core[web-api]
-OpenFisca-France
-OpenFisca-Tracker == 0.4.0


### PR DESCRIPTION
The latest Core is not compatible with France, and that still causes issues to deploy the latest API. 

Turns out requirements are not installed in the order they are declared as I hoped, my bad. This PR thus explicits the order in the deploy script. It has been tested in production.