### PR TITLE
Return site.fr.openfisca.org

### DIFF
--- a/fr.openfisca.org/fr.openfisca.org.conf
+++ b/fr.openfisca.org/fr.openfisca.org.conf
@@ -76,9 +76,10 @@ server {
     }
 
     location / {
-        proxy_pass http://localhost:2011/;
-        proxy_set_header Host $http_host;
-        proxy_http_version 1.1;
+        proxy_pass https://site.fr.openfisca.org/;
+        proxy_set_header Host $proxy_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_intercept_errors on;
+        expires off;
     }
 }


### PR DESCRIPTION
Solution to serve fr.openfisca.org from Netlify while continuing to serve the rest of services from the VPS.

- At some point, CNAMEs were created to point to different Scalingo instances
- One CNAME was create to point to Netlify
- CNAMEs to Scaling were dropped in favour of VPS
- As VPS urls are subfolder based (/*), fr.openfisca.org/* was not routable to VPS
- Hence, nothing worked

Solution is to create a specific CNAME for Netlify, and route fr to VPS