### PR TITLE
Fix SSL renewal instructions

### DIFF
--- a/guides/Renew-SSL-certificates.md
+++ b/guides/Renew-SSL-certificates.md
@@ -5,6 +5,7 @@
 To renew the SSL certificate of an OpenFisca related application, run the following commands, replacing `fr.openfisca.org` by the domain that needs a certificate update:
 
 ```sh
+mkdir -p /tmp/renew-webroot/.well-known/acme-challenge
 sudo /home/openfisca/.pyenv/shims/certbot certonly --webroot -w /tmp/renew-webroot/ -d fr.openfisca.org
 sudo service nginx reload
 ```
@@ -12,6 +13,7 @@ sudo service nginx reload
 To renew all SSL certificates at once, run the following commands:
 
 ```sh
+mkdir -p /tmp/renew-webroot/.well-known/acme-challenge
 sudo /home/openfisca/.pyenv/shims/certbot -q renew
 sudo service nginx reload
 ```
@@ -21,7 +23,8 @@ sudo service nginx reload
 Make sure you have the cerbot cron file in `/etc/cron.d/certbot` with this inside, so to renew certificates every twelve hours:
 
 ```sh
-0 */12 * * * root /home/openfisca/.pyenv/shims/certbot -q renew
+0 */12 * * * mkdir -p /tmp/renew-webroot/.well-known/acme-challenge
+1 */12 * * * root /home/openfisca/.pyenv/shims/certbot -q renew
 ```
 
 ### Certificates renewal file configuration


### PR DESCRIPTION
SSL renewal fails because temporary folders do not exist by the time the cron job is launched.

The current code fixes it.

I reproduced the error by hand:

```
$ sudo /home/openfisca/.pyenv/shims/certbot -q renew
Encountered exception during recovery: 
Traceback (most recent call last):
  File "/home/openfisca/.pyenv/versions/3.7.0/lib/python3.7/site-packages/certbot/auth_handler.py", line 75, in handle_authorizations
    resp = self._solve_challenges(aauthzrs)
  File "/home/openfisca/.pyenv/versions/3.7.0/lib/python3.7/site-packages/certbot/auth_handler.py", line 126, in _solve_challenges
    resp = self.auth.perform(all_achalls)
  File "/home/openfisca/.pyenv/versions/3.7.0/lib/python3.7/site-packages/certbot/plugins/webroot.py", line 83, in perform
    self._create_challenge_dirs()
  File "/home/openfisca/.pyenv/versions/3.7.0/lib/python3.7/site-packages/certbot/plugins/webroot.py", line 172, in _create_challenge_dirs
    stat_path = os.stat(path)
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/renew-webroot'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/openfisca/.pyenv/versions/3.7.0/lib/python3.7/site-packages/certbot/error_handler.py", line 108, in _call_registered
    self.funcs[-1]()
  File "/home/openfisca/.pyenv/versions/3.7.0/lib/python3.7/site-packages/certbot/auth_handler.py", line 310, in _cleanup_challenges
    self.auth.cleanup(achalls)
  File "/home/openfisca/.pyenv/versions/3.7.0/lib/python3.7/site-packages/certbot/plugins/webroot.py", line 222, in cleanup
    os.remove(validation_path)
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/renew-webroot/.well-known/acme-challenge/zugJ7z4hXTeBlH9HN2LGt9ki1NQfSzEiHTPaaXpGELo'
Attempting to renew cert (legislation.openfisca.fr) from /etc/letsencrypt/renewal/legislation.openfisca.fr.conf produced an unexpected error: [Errno 2] No such file or directory: '/tmp/renew-webroot'. Skipping.
Encountered exception during recovery: 
Traceback (most recent call last):
  File "/home/openfisca/.pyenv/versions/3.7.0/lib/python3.7/site-packages/certbot/auth_handler.py", line 75, in handle_authorizations
    resp = self._solve_challenges(aauthzrs)
  File "/home/openfisca/.pyenv/versions/3.7.0/lib/python3.7/site-packages/certbot/auth_handler.py", line 126, in _solve_challenges
    resp = self.auth.perform(all_achalls)
  File "/home/openfisca/.pyenv/versions/3.7.0/lib/python3.7/site-packages/certbot/plugins/webroot.py", line 83, in perform
    self._create_challenge_dirs()
  File "/home/openfisca/.pyenv/versions/3.7.0/lib/python3.7/site-packages/certbot/plugins/webroot.py", line 172, in _create_challenge_dirs
    stat_path = os.stat(path)
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/renew-webroot'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/openfisca/.pyenv/versions/3.7.0/lib/python3.7/site-packages/certbot/error_handler.py", line 108, in _call_registered
    self.funcs[-1]()
  File "/home/openfisca/.pyenv/versions/3.7.0/lib/python3.7/site-packages/certbot/auth_handler.py", line 310, in _cleanup_challenges
    self.auth.cleanup(achalls)
  File "/home/openfisca/.pyenv/versions/3.7.0/lib/python3.7/site-packages/certbot/plugins/webroot.py", line 222, in cleanup
    os.remove(validation_path)
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/renew-webroot/.well-known/acme-challenge/olH8x-GSoRQgxeqRhaoiyxRrMKbNhlHRXC8KjaqOnXg'
Attempting to renew cert (demo.openfisca.org) from /etc/letsencrypt/renewal/demo.openfisca.org.conf produced an unexpected error: [Errno 2] No such file or directory: '/tmp/renew-webroot'. Skipping.
Encountered exception during recovery: 
Traceback (most recent call last):
  File "/home/openfisca/.pyenv/versions/3.7.0/lib/python3.7/site-packages/certbot/auth_handler.py", line 75, in handle_authorizations
    resp = self._solve_challenges(aauthzrs)
  File "/home/openfisca/.pyenv/versions/3.7.0/lib/python3.7/site-packages/certbot/auth_handler.py", line 126, in _solve_challenges
    resp = self.auth.perform(all_achalls)
  File "/home/openfisca/.pyenv/versions/3.7.0/lib/python3.7/site-packages/certbot/plugins/webroot.py", line 83, in perform
    self._create_challenge_dirs()
  File "/home/openfisca/.pyenv/versions/3.7.0/lib/python3.7/site-packages/certbot/plugins/webroot.py", line 172, in _create_challenge_dirs
    stat_path = os.stat(path)
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/renew-webroot'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/openfisca/.pyenv/versions/3.7.0/lib/python3.7/site-packages/certbot/error_handler.py", line 108, in _call_registered
    self.funcs[-1]()
  File "/home/openfisca/.pyenv/versions/3.7.0/lib/python3.7/site-packages/certbot/auth_handler.py", line 310, in _cleanup_challenges
    self.auth.cleanup(achalls)
  File "/home/openfisca/.pyenv/versions/3.7.0/lib/python3.7/site-packages/certbot/plugins/webroot.py", line 222, in cleanup
    os.remove(validation_path)
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/renew-webroot/.well-known/acme-challenge/9-UTGvj8wx4RH9yNGP_tUbjspNj5wCygG528AGGPE7o'
Attempting to renew cert (www.openfisca.fr-0001) from /etc/letsencrypt/renewal/www.openfisca.fr-0001.conf produced an unexpected error: [Errno 2] No such file or directory: '/tmp/renew-webroot'. Skipping.
Encountered exception during recovery: 
Traceback (most recent call last):
  File "/home/openfisca/.pyenv/versions/3.7.0/lib/python3.7/site-packages/certbot/auth_handler.py", line 75, in handle_authorizations
    resp = self._solve_challenges(aauthzrs)
  File "/home/openfisca/.pyenv/versions/3.7.0/lib/python3.7/site-packages/certbot/auth_handler.py", line 126, in _solve_challenges
    resp = self.auth.perform(all_achalls)
  File "/home/openfisca/.pyenv/versions/3.7.0/lib/python3.7/site-packages/certbot/plugins/webroot.py", line 83, in perform
    self._create_challenge_dirs()
  File "/home/openfisca/.pyenv/versions/3.7.0/lib/python3.7/site-packages/certbot/plugins/webroot.py", line 172, in _create_challenge_dirs
    stat_path = os.stat(path)
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/renew-webroot'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/openfisca/.pyenv/versions/3.7.0/lib/python3.7/site-packages/certbot/error_handler.py", line 108, in _call_registered
    self.funcs[-1]()
  File "/home/openfisca/.pyenv/versions/3.7.0/lib/python3.7/site-packages/certbot/auth_handler.py", line 310, in _cleanup_challenges
    self.auth.cleanup(achalls)
  File "/home/openfisca/.pyenv/versions/3.7.0/lib/python3.7/site-packages/certbot/plugins/webroot.py", line 222, in cleanup
    os.remove(validation_path)
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/renew-webroot/.well-known/acme-challenge/P0ffQBfgaI0vUZe9zqWEj_gcPvbfTgZTPe4ZAHNnFJo'
Attempting to renew cert (fr.openfisca.org) from /etc/letsencrypt/renewal/fr.openfisca.org.conf produced an unexpected error: [Errno 2] No such file or directory: '/tmp/renew-webroot'. Skipping.
Encountered exception during recovery: 
Traceback (most recent call last):
  File "/home/openfisca/.pyenv/versions/3.7.0/lib/python3.7/site-packages/certbot/auth_handler.py", line 75, in handle_authorizations
    resp = self._solve_challenges(aauthzrs)
  File "/home/openfisca/.pyenv/versions/3.7.0/lib/python3.7/site-packages/certbot/auth_handler.py", line 126, in _solve_challenges
    resp = self.auth.perform(all_achalls)
  File "/home/openfisca/.pyenv/versions/3.7.0/lib/python3.7/site-packages/certbot/plugins/webroot.py", line 83, in perform
    self._create_challenge_dirs()
  File "/home/openfisca/.pyenv/versions/3.7.0/lib/python3.7/site-packages/certbot/plugins/webroot.py", line 172, in _create_challenge_dirs
    stat_path = os.stat(path)
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/renew-webroot'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/openfisca/.pyenv/versions/3.7.0/lib/python3.7/site-packages/certbot/error_handler.py", line 108, in _call_registered
    self.funcs[-1]()
  File "/home/openfisca/.pyenv/versions/3.7.0/lib/python3.7/site-packages/certbot/auth_handler.py", line 310, in _cleanup_challenges
    self.auth.cleanup(achalls)
  File "/home/openfisca/.pyenv/versions/3.7.0/lib/python3.7/site-packages/certbot/plugins/webroot.py", line 222, in cleanup
    os.remove(validation_path)
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/renew-webroot/.well-known/acme-challenge/ixqzRY3ZCFEe1zGBdyvvG4DfHR-mhSDd09ioqpkW5yA'
Attempting to renew cert (openfisca.fr) from /etc/letsencrypt/renewal/openfisca.fr.conf produced an unexpected error: [Errno 2] No such file or directory: '/tmp/renew-webroot'. Skipping.
All renewal attempts failed. The following certs could not be renewed:
  /etc/letsencrypt/live/legislation.openfisca.fr/fullchain.pem (failure)
  /etc/letsencrypt/live/demo.openfisca.org/fullchain.pem (failure)
  /etc/letsencrypt/live/www.openfisca.fr-0001/fullchain.pem (failure)
  /etc/letsencrypt/live/fr.openfisca.org/fullchain.pem (failure)
  /etc/letsencrypt/live/openfisca.fr/fullchain.pem (failure)
5 renew failure(s), 0 parse failure(s)
```