### PR TITLE
[WIP] Install OpenFisca API with Ansible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.project
+/.vagrant/
 .DS_Store

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,12 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/focal64"
+
+  # Used to refer to this VM from Ansible playbooks.
+  config.vm.define "openfisca_api"
+
+  config.vm.network "forwarded_port", guest: 80, host: 8000
+
+  config.vm.provision :ansible do |ansible|
+    ansible.playbook = "ansible/openfisca-api.yml"
+  end
+end

--- a/ansible/host_vars/openfisca_api.yml
+++ b/ansible/host_vars/openfisca_api.yml
@@ -1,0 +1,1 @@
+host_name: openfisca-api.local

--- a/ansible/openfisca-api.yml
+++ b/ansible/openfisca-api.yml
@@ -1,0 +1,6 @@
+---
+- name: Install OpenFisca Web API
+  become: yes
+  hosts: openfisca_api
+  roles:
+    - openfisca-api

--- a/ansible/roles/openfisca-api/defaults/main.yml
+++ b/ansible/roles/openfisca-api/defaults/main.yml
@@ -1,0 +1,7 @@
+base_url_path: /api/latest
+host_name: fr.openfisca.org
+http_port: 8000
+nb_workers: 2
+unix_group_name: openfisca
+unix_user_name: openfisca-api
+welcome_message: Welcome to OpenFisca Web API. This instance runs OpenFisca-France country package.

--- a/ansible/roles/openfisca-api/handlers/main.yml
+++ b/ansible/roles/openfisca-api/handlers/main.yml
@@ -1,0 +1,4 @@
+- name: Reload nginx
+  ansible.builtin.systemd:
+    name: nginx
+    state: reloaded

--- a/ansible/roles/openfisca-api/tasks/main.yml
+++ b/ansible/roles/openfisca-api/tasks/main.yml
@@ -1,0 +1,70 @@
+- name: Install OS packages
+  ansible.builtin.apt:
+    install_recommends: no
+    name:
+      - acl # Provides "setfacl" command, used by Ansible to become another Unix user
+      - nginx
+      - python3.9
+      - python3-pip
+      - python3-virtualenv
+    state: present
+    update_cache: yes
+
+- name: Create Unix group for OpenFisca
+  ansible.builtin.group:
+    name: "{{ unix_group_name }}"
+    state: present
+
+- name: Create Unix user for OpenFisca Web API
+  ansible.builtin.user:
+    name: "{{ unix_user_name }}"
+    group: "{{ unix_group_name }}"
+  register: unix_user
+
+- name: Define virtualenv directory from Unix user home directory
+  ansible.builtin.set_fact:
+    venv_dir: "{{ unix_user.home }}/venv"
+
+- name: Install latest version of OpenFisca Web API in virtualenv with OpenFisca-France
+  ansible.builtin.pip:
+    # Using chdir to solve an error as explained by [this comment](https://github.com/ansible/ansible/issues/22967#issuecomment-500604054)
+    chdir: "{{ venv_dir }}"
+    name:
+      - OpenFisca-Core[web-api]
+      - OpenFisca-France
+    state: latest
+    virtualenv: "{{ venv_dir }}"
+    virtualenv_site_packages: no
+  become_user: "{{ unix_user_name }}"
+
+- name: Copy systemd service file
+  ansible.builtin.template:
+    src: systemd/openfisca-web-api-fr.service.j2
+    dest: /etc/systemd/system/openfisca-web-api-fr.service
+
+- name: Enable and start systemd service
+  ansible.builtin.systemd:
+    daemon_reload: yes
+    enabled: yes
+    state: restarted
+    name: openfisca-web-api-fr
+
+- name: Check that OpenFisca Web API is actually started
+  ansible.builtin.uri:
+    return_content: yes
+    status_code: 300
+    url: "http://localhost:{{ http_port }}"
+  register: this
+  failed_when: this.json.welcome != welcome_message
+
+- name: Copy nginx vhost file to available sites directory
+  ansible.builtin.template:
+    src: nginx/openfisca-web-api.conf.j2
+    dest: "/etc/nginx/sites-available/{{ host_name }}.conf"
+
+- name: Link nginx vhost file to enabled sites directory
+  ansible.builtin.file:
+    src: "/etc/nginx/sites-available/{{ host_name }}.conf"
+    dest: "/etc/nginx/sites-enabled/{{ host_name }}.conf"
+    state: link
+  notify: Reload nginx

--- a/ansible/roles/openfisca-api/templates/nginx/openfisca-web-api.conf.j2
+++ b/ansible/roles/openfisca-api/templates/nginx/openfisca-web-api.conf.j2
@@ -1,0 +1,12 @@
+server {
+    listen 80;
+    server_name {{ host_name }};
+
+    access_log /var/log/nginx/{{ host_name }}}-access.log;
+    error_log /var/log/nginx/{{ host_name }}}-error.log;
+
+    location {{ base_url_path | default("/") }} {
+        include proxy_params;
+        proxy_pass http://localhost:{{ http_port }}/;
+    }
+}

--- a/ansible/roles/openfisca-api/templates/systemd/openfisca-web-api-fr.service.j2
+++ b/ansible/roles/openfisca-api/templates/systemd/openfisca-web-api-fr.service.j2
@@ -1,0 +1,11 @@
+[Unit]
+Description=OpenFisca Web API - France
+
+[Service]
+ExecStart={{ venv_dir }}/bin/openfisca serve --port {{ http_port }} --workers {{ nb_workers }} --country-package openfisca_france --welcome-message {{ welcome_message | quote }}
+User={{ unix_user_name }}
+Group={{ unix_group_name }}
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/guides/Install-API-instance.md
+++ b/guides/Install-API-instance.md
@@ -1,0 +1,56 @@
+# Install an instance of OpenFisca Web API automatically
+
+This repository provides a way to install the OpenFisca Web API automatically on a machine that exposes a SSH connection.
+
+This installation method uses [Ansible](https://www.ansible.com/), a well-known open-source tool enabling infrastructure as code, and is implemented as an Ansible playbook.
+
+This documentation page describes how to run this Ansible playbook targeting a remote server, or a virtual machine (VM) managed locally on your development machine.
+
+## Requirements
+
+The Ansible tool must be installed on a machine named [control node](https://docs.ansible.com/ansible/latest/network/getting_started/basic_concepts.html#control-node) in Ansible parlance that will install OpenFisca Web API on a [managed node](https://docs.ansible.com/ansible/latest/network/getting_started/basic_concepts.html#managed-nodes). The control node can be, for example, your development machine.
+
+To install Ansible, check [its documentation](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html).
+
+## On a remote server
+
+This scenario describes how to install OpenFisca Web API on a remote server. The only requirement is that this server must expose an SSH connection.
+
+## On a local VM
+
+This scenario describes how to install OpenFisca Web API on a virtual machine (VM) managed locally on your development machine by [Vagrant](https://www.vagrantup.com/), a well-known open-source tool.
+
+To install Vagrant, check [its documentation](https://www.vagrantup.com/docs/installation).
+
+The VM is defined by the [`Vagrantfile`](../Vagrantfile) and references the [Ansible playbook](../ansible/openfisca-api.yml) that installs OpenFisca Web API.
+
+To create the VM then run the Ansible playbook, just do:
+
+```bash
+# Ensure you are in the directory containing the Vagrantfile
+cd openfisca-ops
+
+vagrant up
+```
+
+About a minute later, the command will finish, and you should have a VM with OpenFisca Web API running. Thanks to Vagrant port forwarding, the internal port 8000 inside the VM is forwarded to the port 80 of your development machine.
+
+To try the API, you must first associate the host name serving the API in your `/etc/hosts` file to the local machine, by adding this line:
+
+```text
+127.0.0.1 openfisca-api.local
+```
+
+Note: this host name serving the API is defined in [`host_vars/openfisca_api.yml`](../ansible/host_vars/openfisca_api.yml) that is taken into account by Ansible only when the VM host name is `openfisca_api`. The `Vagrantfile` defines that VM host name.
+
+Then you can do:
+
+```bash
+curl http://openfisca-api.local:8000/api/latest
+```
+
+This should display the following JSON result:
+
+```text
+{"welcome":"Welcome to OpenFisca Web API. This instance runs OpenFisca-France country package."}
+```


### PR DESCRIPTION
This PR:

- [x] provides an Ansible playbook named `openfisca-api` that automates the installation of OpenFisca Web API with the OpenFisca-France country package
- [x] a `Vagrantfile` to ease local development by automating the provisioning of a local VM
- [x] documentation for the deployment to a local VM scenario

Note: I started by using Vagrant because it was an easy way to try the Ansible playbook locally.

Remaining tasks:

- [ ] validate that the Ansible playbook works on a remote server (in particular handle Ansible variable overloading)
- [ ] documentation for the remote deployment scenario
