### PR TITLE
Reverse-proxify Legislation Explorer from another host

### DIFF
--- a/fr.openfisca.org/fr.openfisca.org.conf
+++ b/fr.openfisca.org/fr.openfisca.org.conf
@@ -1,5 +1,5 @@
 upstream legislation-explorer {
-    server localhost:2030;
+    server 141.94.20.107:2030;
 }
 
 server {


### PR DESCRIPTION
## Problem

Legislation Explorer is down on the production server, the symptom is a "bad gateway" error.

<details>
<summary>More context</summary>
The node application is stuck in an infinite loop when starting, with this error:

```
$ systemctl status legislation-explorer.service

Oct 08 14:08:00 vps223769.ovh.net systemd[1]: Started OpenFisca Legislation Explorer.
Oct 08 14:08:00 vps223769.ovh.net npm[2464]: > legislation-explorer@1.0.0 start /home/openfisca/legislation-explorer
Oct 08 14:08:00 vps223769.ovh.net npm[2464]: > NODE_ENV=production node --require dotenv/config index.js
Oct 08 14:08:03 vps223769.ovh.net npm[2464]: Fetching variables and parameters on Web API...
Oct 08 14:08:03 vps223769.ovh.net npm[2464]: error: Error: Could not fetch 'https://fr.openfisca.org/api/latest/entities'.
Oct 08 14:08:03 vps223769.ovh.net npm[2464]:     at /home/openfisca/legislation-explorer/src/webservices.js:8:26
Oct 08 14:08:03 vps223769.ovh.net npm[2464]:     at process._tickCallback (internal/process/next_tick.js:109:7)
Oct 08 14:08:03 vps223769.ovh.net systemd[1]: legislation-explorer.service: Service hold-off time over, scheduling restart.
Oct 08 14:08:03 vps223769.ovh.net systemd[1]: Stopped OpenFisca Legislation Explorer.
Oct 08 14:08:03 vps223769.ovh.net systemd[1]: Started OpenFisca Legislation Explorer.
[... etc ...]
```

After commenting the line `mozilla DST_Root_CA_X3.crt` in `/etc/ca-certificates.conf` (due to the recent [DST Root CA X3 Expiration](https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/)), the API is now loadable via `curl`:

```
$ curl -I https://fr.openfisca.org/api/latest 
HTTP/1.1 300 MULTIPLE CHOICES
$ curl -I https://fr.openfisca.org/api/latest/entities
HTTP/1.1 200 OK
```

However, trying to load those API URLs fails from node:

```
$ node
> require("isomorphic-fetch")
[Function]
> fetch("https://fr.openfisca.org/api/latest").then(console.log, console.error)
Promise { <pending> }
> { FetchError: request to https://fr.openfisca.org/api/latest failed, reason: certificate has expired
    at ClientRequest.<anonymous> (/home/openfisca/legislation-explorer/node_modules/node-fetch/index.js:133:11)
    at emitOne (events.js:96:13)
    at ClientRequest.emit (events.js:188:7)
    at TLSSocket.socketErrorListener (_http_client.js:314:9)
    at emitOne (events.js:96:13)
    at TLSSocket.emit (events.js:188:7)
    at emitErrorNT (net.js:1290:8)
    at _combinedTickCallback (internal/process/next_tick.js:80:11)
    at process._tickDomainCallback (internal/process/next_tick.js:128:9)
  name: 'FetchError',
  message: 'request to https://fr.openfisca.org/api/latest failed, reason: certificate has expired',
  type: 'system',
  errno: 'CERT_HAS_EXPIRED',
  code: 'CERT_HAS_EXPIRED' }
```

It makes me think that node does not use the `/etc/ca-certificates` configuration.

</details>

## Solution

The solution consists in using the new staging server, that uses a recent Debian distribution, to install a fresh instance of the Legislation Explorer. To do so, a new Ansible playbook has been written, cf https://github.com/openfisca/legislation-explorer/pull/231

To do so, the configuration of Nginx on the production server has to be modified to reverse-proxy the Legislation Explorer from another IP address. That's the purpose of the present PR.

### About SSL

The staging server serves Legislation Explorer with HTTP.

The production server already serves `fr.openfisca.org` with HTTPS.
