### PR TITLE
Do not prefix all variables

### DIFF
--- a/ansible/inventories/YOUR_INVENTORY.yml
+++ b/ansible/inventories/YOUR_INVENTORY.yml
@@ -3,7 +3,7 @@ all:
     SERVER_IP_OR_HOST_NAME: # replace that placeholder with the IP address or host name of the server
       ansible_user: root
       # adjust the variables defined in `ansible/roles/openfisca_api_fr/defaults/main.yml` below:
-      openfisca_api_fr_host_name: fr.openfisca.org
-      openfisca_api_fr_enable_ssl: yes
-      openfisca_api_fr_letsencrypt_email: contact@openfisca.org
-      openfisca_api_fr_letsencrypt_environment: "production"
+      host_name: fr.openfisca.org
+      enable_ssl: yes
+      letsencrypt_email: contact@openfisca.org
+      letsencrypt_environment: "production"

--- a/ansible/inventories/ovh.yml
+++ b/ansible/inventories/ovh.yml
@@ -5,10 +5,10 @@ all:
 
       # OpenFisca Web API
       # adjust the variables defined in `ansible/roles/openfisca_api_fr/defaults/main.yml` below:
-      openfisca_api_fr_host_name: api.fr.openfisca.org
-      openfisca_api_fr_enable_ssl: yes
-      openfisca_api_fr_letsencrypt_email: contact@openfisca.org
-      openfisca_api_fr_letsencrypt_environment: "production"
+      host_name: api.fr.openfisca.org
+      enable_ssl: yes
+      letsencrypt_email: contact@openfisca.org
+      letsencrypt_environment: "production"
 
       # Legislation Explorer
       legislation_explorer_api_url: https://fr.openfisca.org/api/latest

--- a/ansible/roles/openfisca_api_fr/defaults/main.yml
+++ b/ansible/roles/openfisca_api_fr/defaults/main.yml
@@ -1,31 +1,31 @@
-openfisca_api_fr_base_url_path: /api/latest
-openfisca_api_fr_env_file: /etc/openfisca/openfisca-web-api-fr.env
-openfisca_api_fr_host_name: localhost
-openfisca_api_fr_http_port: 8000
-openfisca_api_fr_nb_workers: 2
-openfisca_api_fr_systemd_service_file: /etc/systemd/system/openfisca-web-api-fr.service
-openfisca_api_fr_unix_group_name: openfisca
-openfisca_api_fr_unix_user_name: openfisca-api
-openfisca_api_fr_welcome_message: Welcome to the OpenFisca Web API. This instance runs the OpenFisca-France country package.
+base_url_path: /api/latest
+env_file: /etc/openfisca/openfisca-web-api-fr.env
+host_name: localhost
+http_port: 8000
+nb_workers: 2
+systemd_service_file: /etc/systemd/system/openfisca-web-api-fr.service
+unix_group_name: openfisca
+unix_user_name: openfisca-api
+welcome_message: Welcome to the OpenFisca Web API. This instance runs the OpenFisca-France country package.
 
 # Optional: auto-update
 
-openfisca_api_fr_autoupdate_enable: yes
-openfisca_api_fr_autoupdate_unix_group_name: "{{ openfisca_api_fr_unix_group_name }}"
-openfisca_api_fr_autoupdate_unix_user_name: openfisca-ops
-openfisca_api_fr_autoupdate_ops_branch_name: install-api-with-ansible
-openfisca_api_fr_autoupdate_ops_repo_url: https://github.com/openfisca/openfisca-ops.git
+autoupdate_enable: yes
+autoupdate_unix_group_name: "{{ unix_group_name }}"
+autoupdate_unix_user_name: openfisca-ops
+autoupdate_ops_branch_name: install-api-with-ansible
+autoupdate_ops_repo_url: https://github.com/openfisca/openfisca-ops.git
 
 # Optional: SSL certificate
-# An SSL certificate is issued from Let's Encrypt if `openfisca_api_fr_enable_ssl` and `openfisca_api_fr_letsencrypt_email` are both defined.
-openfisca_api_fr_enable_ssl: no
-openfisca_api_fr_letsencrypt_email: null
+# An SSL certificate is issued from Let's Encrypt if `enable_ssl` and `letsencrypt_email` are both defined.
+enable_ssl: no
+letsencrypt_email: null
 # Start by testing with staging environment, then switch to production once it works, to avoid reaching Let's Encrypt limits.
-openfisca_api_fr_letsencrypt_environment: "staging"
+letsencrypt_environment: "staging"
 
 # Optional: Matomo tracker
-# Matomo tracker is enabled if both variables `openfisca_api_fr_matomo_site_id` and `openfisca_api_fr_matomo_url` are defined.
-openfisca_api_fr_matomo_site_id: null
-openfisca_api_fr_matomo_url: null
-openfisca_api_fr_matomo_token: "{{ lookup('env','OPENFISCA_API_FR_MATOMO_TOKEN') }}"
-openfisca_api_fr_matomo_enabled: "{{ openfisca_api_fr_matomo_site_id and openfisca_api_fr_matomo_token and openfisca_api_fr_matomo_url }}"
+# Matomo tracker is enabled if both variables `matomo_site_id` and `matomo_url` are defined.
+matomo_site_id: null
+matomo_url: null
+matomo_token: "{{ lookup('env','MATOMO_TOKEN') }}"
+matomo_enabled: "{{ matomo_site_id and matomo_token and matomo_url }}"

--- a/ansible/roles/openfisca_api_fr/tasks/main.yml
+++ b/ansible/roles/openfisca_api_fr/tasks/main.yml
@@ -35,39 +35,39 @@
 
 - name: Create a Unix group for the OpenFisca Web API
   ansible.builtin.group:
-    name: "{{ openfisca_api_fr_unix_group_name }}"
+    name: "{{ unix_group_name }}"
     state: present
 
 - name: Create a Unix user for the OpenFisca Web API
   ansible.builtin.user:
-    name: "{{ openfisca_api_fr_unix_user_name }}"
-    group: "{{ openfisca_api_fr_unix_group_name }}"
+    name: "{{ unix_user_name }}"
+    group: "{{ unix_group_name }}"
     shell: /bin/bash
-  register: openfisca_api_fr_unix_user
+  register: unix_user
 
 - name: Define a directory to store the virtualenv of OpenFisca Web API
   ansible.builtin.set_fact:
-    openfisca_api_fr_venv_dir: "{{ openfisca_api_fr_unix_user.home }}/venv"
+    venv_dir: "{{ unix_user.home }}/venv"
 
 - name: Install the latest version of OpenFisca Web API in the virtualenv with OpenFisca-France
   ansible.builtin.pip:
     # Using chdir to solve an error as explained by [this comment](https://github.com/ansible/ansible/issues/22967#issuecomment-500604054)
-    chdir: "{{ openfisca_api_fr_venv_dir }}"
+    chdir: "{{ venv_dir }}"
     name:
       - OpenFisca-Core[web-api]
       - OpenFisca-France
     state: latest
-    virtualenv: "{{ openfisca_api_fr_venv_dir }}"
+    virtualenv: "{{ venv_dir }}"
     virtualenv_python: python3.7
     virtualenv_site_packages: no
-  become_user: "{{ openfisca_api_fr_unix_user_name }}"
+  become_user: "{{ unix_user_name }}"
   notify: Reload nginx
 
 - name: Setup the systemd service
   block:
     - name: Create the directory receiving the environment file
       ansible.builtin.file:
-        path: "{{ openfisca_api_fr_env_file | dirname }}"
+        path: "{{ env_file | dirname }}"
         state: directory
         mode: "0755"
 
@@ -75,13 +75,13 @@
       ansible.builtin.template:
         backup: yes
         src: systemd/openfisca-web-api-fr.env.j2
-        dest: "{{ openfisca_api_fr_env_file }}"
+        dest: "{{ env_file }}"
 
     - name: Copy the systemd service file
       ansible.builtin.template:
         backup: yes
         src: systemd/openfisca-web-api-fr.service.j2
-        dest: "{{ openfisca_api_fr_systemd_service_file }}"
+        dest: "{{ systemd_service_file }}"
 
     - name: Enable and start the systemd service
       ansible.builtin.systemd:
@@ -95,7 +95,7 @@
     return_content: yes
     status_code: 300
     timeout: 120
-    url: "http://localhost:{{ openfisca_api_fr_http_port }}"
+    url: "http://localhost:{{ http_port }}"
   register: this
   until: this.status == 300
   retries: 5 # times
@@ -105,17 +105,17 @@
   ansible.builtin.template:
     backup: yes
     src: nginx/openfisca-web-api.conf.j2
-    dest: "/etc/nginx/sites-available/{{ openfisca_api_fr_host_name }}.conf"
+    dest: "/etc/nginx/sites-available/{{ host_name }}.conf"
 
 - name: Link the nginx vhost file to the sites-enabled directory of Nginx
   ansible.builtin.file:
-    src: "/etc/nginx/sites-available/{{ openfisca_api_fr_host_name }}.conf"
-    dest: "/etc/nginx/sites-enabled/{{ openfisca_api_fr_host_name }}.conf"
+    src: "/etc/nginx/sites-available/{{ host_name }}.conf"
+    dest: "/etc/nginx/sites-enabled/{{ host_name }}.conf"
     state: link
   notify: Reload nginx
 
 - name: Setup SSL
-  when: openfisca_api_fr_enable_ssl and openfisca_api_fr_letsencrypt_email
+  when: enable_ssl and letsencrypt_email
   block:
     - name: Install Certbot and its Nginx plugin
       ansible.builtin.apt:
@@ -127,7 +127,7 @@
         update_cache: no
 
     - name: Handle staging environment
-      when: openfisca_api_fr_letsencrypt_environment == "staging"
+      when: letsencrypt_environment == "staging"
       block:
         - name: Display message when staging environment is used
           ansible.builtin.debug:
@@ -140,9 +140,9 @@
     - name: Reinstall or renew an SSL certificate from Let's Encrypt using the certbot client
       ansible.builtin.command: >
         certbot
-        --non-interactive --email {{ openfisca_api_fr_letsencrypt_email }} --agree-tos
+        --non-interactive --email {{ letsencrypt_email }} --agree-tos
         --nginx --redirect
-        --domains {{ openfisca_api_fr_host_name }} --keep-until-expiring
+        --domains {{ host_name }} --keep-until-expiring
         {{ certbot_staging_option | default() }}
       become_user: root
       register: certbot_result
@@ -151,7 +151,7 @@
       ansible.builtin.lineinfile:
         backrefs: yes
         line: '\1\2 http2;\3'
-        path: "/etc/nginx/sites-available/{{ openfisca_api_fr_host_name }}.conf"
+        path: "/etc/nginx/sites-available/{{ host_name }}.conf"
         regexp: "^(.*)(listen 443 ssl);(.+)$"
       notify: Reload nginx
       tags:
@@ -160,7 +160,7 @@
 - name: Setup auto-update
   tags:
     - auto-update
-  when: openfisca_api_fr_autoupdate_enable
+  when: autoupdate_enable
   block:
     - name: Add the "ansible" PPA
       ansible.builtin.apt_repository:
@@ -178,22 +178,22 @@
 
     - name: Create the Unix group for auto-update
       ansible.builtin.group:
-        name: "{{ openfisca_api_fr_autoupdate_unix_group_name }}"
+        name: "{{ autoupdate_unix_group_name }}"
         state: present
 
     - name: Create the Unix user for auto-update
       ansible.builtin.user:
-        name: "{{ openfisca_api_fr_autoupdate_unix_user_name }}"
-        group: "{{ openfisca_api_fr_autoupdate_unix_group_name }}"
+        name: "{{ autoupdate_unix_user_name }}"
+        group: "{{ autoupdate_unix_group_name }}"
         shell: /bin/bash
-      register: openfisca_api_fr_autoupdate_unix_user
+      register: autoupdate_unix_user
 
     - name: Clone or update the "openfisca-ops" Git repository
       ansible.builtin.git:
-        repo: "{{ openfisca_api_fr_autoupdate_ops_repo_url }}"
-        dest: "{{ openfisca_api_fr_autoupdate_unix_user.home }}/openfisca-ops"
-        version: "{{ openfisca_api_fr_autoupdate_ops_branch_name }}"
-      become_user: "{{ openfisca_api_fr_autoupdate_unix_user_name }}"
+        repo: "{{ autoupdate_ops_repo_url }}"
+        dest: "{{ autoupdate_unix_user.home }}/openfisca-ops"
+        version: "{{ autoupdate_ops_branch_name }}"
+      become_user: "{{ autoupdate_unix_user_name }}"
 
     - name: Copy the cron job definition
       ansible.builtin.template:

--- a/ansible/roles/openfisca_api_fr/templates/nginx/openfisca-web-api.conf.j2
+++ b/ansible/roles/openfisca_api_fr/templates/nginx/openfisca-web-api.conf.j2
@@ -2,19 +2,19 @@
 
 server {
     listen 80;
-    server_name {{ openfisca_api_fr_host_name }};
+    server_name {{ host_name }};
 
-    access_log /var/log/nginx/{{ openfisca_api_fr_host_name }}-access.log;
-    error_log /var/log/nginx/{{ openfisca_api_fr_host_name }}-error.log;
+    access_log /var/log/nginx/{{ host_name }}-access.log;
+    error_log /var/log/nginx/{{ host_name }}-error.log;
 
-    location {{ openfisca_api_fr_base_url_path }} {
+    location {{ base_url_path }} {
         # Allow OpenFisca Web API to generate URLs taking the base URL path into account
-        proxy_set_header Host $http_host{{ openfisca_api_fr_base_url_path }};
+        proxy_set_header Host $http_host{{ base_url_path }};
 
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
 
-        proxy_pass http://localhost:{{ openfisca_api_fr_http_port }}/;
+        proxy_pass http://localhost:{{ http_port }}/;
     }
 }

--- a/ansible/roles/openfisca_api_fr/templates/systemd/openfisca-web-api-fr.env.j2
+++ b/ansible/roles/openfisca_api_fr/templates/systemd/openfisca-web-api-fr.env.j2
@@ -1,3 +1,3 @@
-{% if openfisca_api_fr_matomo_enabled %}
-TRACKER_TOKEN={{ openfisca_api_fr_matomo_token | quote }}
+{% if matomo_enabled %}
+TRACKER_TOKEN={{ matomo_token | quote }}
 {% endif %}

--- a/ansible/roles/openfisca_api_fr/templates/systemd/openfisca-web-api-fr.service.j2
+++ b/ansible/roles/openfisca_api_fr/templates/systemd/openfisca-web-api-fr.service.j2
@@ -2,19 +2,19 @@
 Description=OpenFisca Web API - France
 
 [Service]
-EnvironmentFile={{ openfisca_api_fr_env_file }}
-ExecStart={{ openfisca_api_fr_venv_dir }}/bin/openfisca serve \
+EnvironmentFile={{ env_file }}
+ExecStart={{ venv_dir }}/bin/openfisca serve \
     --country-package openfisca_france \
-    --port {{ openfisca_api_fr_http_port }} \
-{% if openfisca_api_fr_matomo_enabled %}
-    --tracker-idsite {{ openfisca_api_fr_matomo_site_id }} \
+    --port {{ http_port }} \
+{% if matomo_enabled %}
+    --tracker-idsite {{ matomo_site_id }} \
     --tracker-token $TRACKER_TOKEN \
-    --tracker-url {{ openfisca_api_fr_matomo_url }} \
+    --tracker-url {{ matomo_url }} \
 {% endif %}
-    --welcome-message {{ openfisca_api_fr_welcome_message | quote }} \
-    --workers {{ openfisca_api_fr_nb_workers }}
-User={{ openfisca_api_fr_unix_user_name }}
-Group={{ openfisca_api_fr_unix_group_name }}
+    --welcome-message {{ welcome_message | quote }} \
+    --workers {{ nb_workers }}
+User={{ unix_user_name }}
+Group={{ unix_group_name }}
 Restart=always
 
 [Install]

--- a/guides/Install-API-instance.md
+++ b/guides/Install-API-instance.md
@@ -42,7 +42,7 @@ all:
     target.ip.or.domain.com: # define here the target machine’s IP or domain name
       ansible_user: root # define here the username to use when connecting over SSH
       # adjust the variables defined in `ansible/roles/openfisca_api_fr/defaults/main.yml` below:
-      openfisca_api_fr_host_name: my-openfisca-api-instance.com
+      host_name: my-openfisca-api-instance.com
 ```
 
 ## 4. Install and start the API
@@ -51,11 +51,11 @@ all:
 2. Navigate to the freshly downloaded folder: `cd openfisca-ops`.
 3. Type the following command: `ansible-playbook --inventory ansible/inventories/YOUR_INVENTORY.yml ansible/site.yml`.
 
-Once the command is done, your target machine should run the OpenFisca France Web API. Just open `http://TARGET_MACHINE:8000/api/latest` in your browser. You can change the port and path through the configuration file, by changing the variables `openfisca_api_fr_base_url_path` or `openfisca_api_fr_http_port`.
+Once the command is done, your target machine should run the OpenFisca France Web API. Just open `http://TARGET_MACHINE:8000/api/latest` in your browser. You can change the port and path through the configuration file, by changing the variables `base_url_path` or `http_port`.
 
 ### Optional: enable Matomo
 
-To track the Web API usage with Matomo, define the Ansible variables `openfisca_api_fr_matomo_site_id` and `openfisca_api_fr_matomo_url` in `YOUR_INVENTORY.yml` and export the environment variable `OPENFISCA_API_FR_MATOMO_TOKEN` before running the `ansible-playbook` command.
+To track the Web API usage with Matomo, define the Ansible variables `matomo_site_id` and `matomo_url` in `YOUR_INVENTORY.yml` and export the environment variable `MATOMO_TOKEN` before running the `ansible-playbook` command.
 
 ## Updates
 


### PR DESCRIPTION
I don't understand the value of prefixing all variables, but I see how it decreases readability 🙂 

This changeset suggests removing the scoping of variables in Ansible.