### PR TITLE
Update the directory of the SSL certificate

### DIFF
--- a/fr.openfisca.org/fr.openfisca.org.conf
+++ b/fr.openfisca.org/fr.openfisca.org.conf
@@ -19,8 +19,8 @@ server {
     listen 443 ssl;
     server_name fr.openfisca.org api.fr.openfisca.org;
 
-    ssl_certificate /etc/letsencrypt/live/fr.openfisca.org/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/fr.openfisca.org/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/fr.openfisca.org-0001/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/fr.openfisca.org-0001/privkey.pem;
 
     access_log /var/log/nginx/fr.openfisca.org-access.log;
     error_log /var/log/nginx/fr.openfisca.org-error.log;


### PR DESCRIPTION
The directory of the SSL certificates of the API changed on the server, from `/etc/letsencrypt/live/fr.openfisca.org` to `/etc/letsencrypt/live/fr.openfisca.org-0001`. This causes the certificate renewal process to fail.

The fix is just to update the directory in the Nginx config. That fix is currenly used on the server, successfully, and this PR keeps those changes safe in the repo.

Note that I did not understand the reason of the change of the directory.