### PR TITLE
Use different times for auto-updating API instances

### DIFF
--- a/ansible/inventories/api.demo.openfisca.org.yml
+++ b/ansible/inventories/api.demo.openfisca.org.yml
@@ -25,6 +25,7 @@ all:
       # autoupdate role
 
       autoupdate_inventory_file: ansible/inventories/api.demo.openfisca.org.yml
+      autoupdate_frequency: "*-*-* 00:00:00"
 
       letsencrypt_email: contact@openfisca.org
       letsencrypt_environment: production

--- a/ansible/inventories/api.fr.openfisca.org.yml
+++ b/ansible/inventories/api.fr.openfisca.org.yml
@@ -25,6 +25,7 @@ all:
       # autoupdate role
 
       autoupdate_inventory_file: ansible/inventories/api.fr.openfisca.org.yml
+      autoupdate_frequency: "*-*-* 01:00:00"
 
       letsencrypt_email: contact@openfisca.org
       letsencrypt_environment: production


### PR DESCRIPTION
Having both instances running with `OnCalendar=daily` results in an apt lock file conflict:

```bash
journalctl -u openfisca-web-api-fr-autoupdate.service -e

Jan 27 00:00:30 vps-60ea1664 ansible-playbook[1699397]:   msg: 'Failed to lock apt for exclusive operation: Failed to lock directory /var/lib/apt/lists/: E:Could not get lock /var/lib/apt/lists/lock. It is held by process 1699661 (python3)
```

https://github.com/openfisca/openfisca-ops/blob/6d3ba21cf907da7a2203124f28d0cbc88aa675c6/ansible/roles/autoupdate/templates/openfisca-web-api-autoupdate.timer.j2#L5