### PR TITLE
Fix variable name to match a previous renaming

### DIFF
--- a/ansible/inventories/api.demo.openfisca.org.yml
+++ b/ansible/inventories/api.demo.openfisca.org.yml
@@ -15,7 +15,7 @@ all:
 
       env_file: /etc/openfisca/openfisca-web-api-demo.env
       systemd_service_file_name: openfisca-web-api-demo.service
-      venv_relative_dir: virtualenvs/openfisca-web-api-demo
+      venv_dir: virtualenvs/openfisca-web-api-demo
 
       # reverse_proxy role
 

--- a/ansible/inventories/api.fr.openfisca.org.yml
+++ b/ansible/inventories/api.fr.openfisca.org.yml
@@ -15,7 +15,7 @@ all:
 
       env_file: /etc/openfisca/openfisca-web-api-fr.env
       systemd_service_file_name: openfisca-web-api-fr.service
-      venv_relative_dir: virtualenvs/openfisca-web-api-fr
+      venv_dir: virtualenvs/openfisca-web-api-fr
 
       # reverse_proxy role
 


### PR DESCRIPTION
(Sorry for the French language, I started replying on Slack, then copy-pasted my answer here)

Après examen sur le serveur je constate que les 2 services systemd `/etc/systemd/system/openfisca-web-api-fr.service`
et `/etc/systemd/system/openfisca-web-api-demo.service` invoquent tous deux l'application avec `ExecStart=/home/openfisca-api/venv/bin/openfisca` (depuis le même virtualenv Python).

Je pense qu'il y a un bug dans les fichiers YAML du rôle `openfisca_api` : la variable `venv_relative_dir` n'est en réalité pas utilisée.

Cela semble être dû à un oubli après renommage de variables Ansible où `venv_relative_dir` est devenu `venv_dir` (cf https://github.com/openfisca/openfisca-ops/commit/9125be058dd26e38fe6fafc9d32c148cf748f464#diff-6b260d1552d035572ac3f267ce79dd0a312de70b22c706563b481ca0071f7528L52)

Par conséquent c'est la valeur par défaut de `venv_dir` qui est utilisée, à savoir `venv` tout court (cf https://github.com/openfisca/openfisca-ops/blob/4dd78ff517161e3b1dd744ecc3ad27c9f7582328/ansible/roles/openfisca_api/defaults/main.yml#L19), et sachant que `venv_path: "{{ unix_user.home }}/{{ venv_dir }}"`, cela correspond au constat initial.

Je pense que la solution est de renommer `venv_relative_dir` en `venv_dir` dans les 2 inventaires.

Le répertoire `/home/openfisca-api/venv` pourra être supprimé après application de la modification.
