### PR TITLE
Upgrade Python to `v3.11`

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,7 +18,8 @@ Vagrant.configure("2") do |config|
     docker.remains_running = true
     docker.has_ssh = true
     docker.privileged = true
-    docker.volumes = ["/sys/fs/cgroup:/sys/fs/cgroup:ro"]
+    docker.volumes = ["/sys/fs/cgroup:/sys/fs/cgroup:rw"]
+    docker.create_args = ["--cgroupns=host"]
   end
 
   config.vm.provision :ansible, run: "always" do |ansible|

--- a/ansible/roles/openfisca_api/defaults/main.yml
+++ b/ansible/roles/openfisca_api/defaults/main.yml
@@ -1,3 +1,5 @@
+python_version: "3.11" # must be string, not a number
+
 app_host: 127.0.0.1
 app_port: 8000
 country_module: openfisca_country_template

--- a/ansible/roles/openfisca_api/defaults/main.yml
+++ b/ansible/roles/openfisca_api/defaults/main.yml
@@ -1,4 +1,4 @@
-python_version: "3.11" # must be string, not a number
+python_version: "3.11" # must be string, not a number; only tested with Python 3
 
 app_host: 127.0.0.1
 app_port: 8000

--- a/ansible/roles/openfisca_api/tasks/health_check.yml
+++ b/ansible/roles/openfisca_api/tasks/health_check.yml
@@ -1,0 +1,10 @@
+- name: Check that OpenFisca Web API is actually started
+  ansible.builtin.uri:
+    return_content: yes
+    status_code: 300
+    timeout: 120
+    url: "http://{{ app_host }}:{{ app_port }}"
+  register: response
+  until: response.status == 300
+  retries: 5
+  delay: 5

--- a/ansible/roles/openfisca_api/tasks/main.yml
+++ b/ansible/roles/openfisca_api/tasks/main.yml
@@ -25,11 +25,15 @@
         name:
           - acl # Provides "setfacl" command, used by Ansible to become another Unix user
           - gcc
-          - python3.7
-          - python3.7-dev
-          - python3-virtualenv
+          - python3.11
+          - python3.11-dev # `python3.11-dev` is needed to install OpenFisca because it includes the Python C API headers required for compilation, `python3.11` would not suffice as it lacks these development tools.
+          - python3.11-venv # Ensure both `ensurepip` and `venv` modules are available
+          - python3-apt
         state: present
         update_cache: no
+
+    - name: Install pip using ensurepip
+      ansible.builtin.command: /usr/bin/python3.11 -m ensurepip
 
 - name: Create a Unix group and user for the OpenFisca Web API
   block:
@@ -51,11 +55,10 @@
       ansible.builtin.set_fact:
         venv_path: "{{ unix_user.home }}/{{ venv_dir }}"
 
-    - name: Create the directory for the virtualenv
-      ansible.builtin.file:
-        path: "{{ venv_path }}"
-        state: directory
-        mode: "0755"
+    - name: Create the virtual environment
+      ansible.builtin.command:
+        cmd: "python3.11 -m venv {{ venv_path }}"
+        creates: "{{ venv_path }}/bin/activate"
       become_user: "{{ unix_user_name }}"
 
     - name: Determine if Matomo is enabled according to role variables
@@ -74,7 +77,7 @@
         name: "{{ item.name }}"
         state: latest
         virtualenv: "{{ venv_path }}"
-        virtualenv_python: python3.7
+        virtualenv_python: python3.11
         virtualenv_site_packages: no
       become_user: "{{ unix_user_name }}"
 

--- a/ansible/roles/openfisca_api/tasks/main.yml
+++ b/ansible/roles/openfisca_api/tasks/main.yml
@@ -71,8 +71,6 @@
         - { name: "{{ country_package }}", enabled: yes }
       when: item.enabled
       ansible.builtin.pip:
-        # Using chdir to solve an error as explained by [this comment](https://github.com/ansible/ansible/issues/22967#issuecomment-500604054)
-        chdir: "{{ venv_path }}"
         name: "{{ item.name }}"
         state: latest
         virtualenv: "{{ venv_path }}"

--- a/ansible/roles/openfisca_api/tasks/main.yml
+++ b/ansible/roles/openfisca_api/tasks/main.yml
@@ -7,10 +7,10 @@
 - name: Create Unix group and user for OpenFisca Web API
   include_tasks: user_setup.yml
 
-- name: Setup and configure OpenFisca Web API
+- name: Set up OpenFisca Web API
   include_tasks: web_api_setup.yml
 
-- name: Deploy and manage systemd service for OpenFisca Web API
+- name: Set up systemd service for OpenFisca Web API
   include_tasks: systemd.yml
 
 - name: Check that OpenFisca Web API is actually started

--- a/ansible/roles/openfisca_api/tasks/main.yml
+++ b/ansible/roles/openfisca_api/tasks/main.yml
@@ -38,17 +38,17 @@
         state: present
         update_cache: no
 
-    - name: Install pip using ensurepip
+    - name: Install pip
       ansible.builtin.command: /usr/bin/python3.11 -m ensurepip
 
-- name: Create a Unix group and user for the OpenFisca Web API
+- name: Create Unix group and user for OpenFisca Web API
   block:
-    - name: Create a Unix group for the OpenFisca Web API
+    - name: Create Unix group for OpenFisca Web API
       ansible.builtin.group:
         name: "{{ unix_group_name }}"
         state: present
 
-    - name: Create a Unix user for the OpenFisca Web API
+    - name: Create Unix user for OpenFisca Web API
       ansible.builtin.user:
         name: "{{ unix_user_name }}"
         group: "{{ unix_group_name }}"
@@ -57,11 +57,11 @@
 
 - name: Install the latest version of OpenFisca Web API in the virtualenv with {{ country_package }}
   block:
-    - name: Define a directory to store the virtualenv of OpenFisca Web API
+    - name: Define the virtual environment directory for OpenFisca Web API
       ansible.builtin.set_fact:
         venv_path: "{{ unix_user.home }}/{{ venv_dir }}"
 
-    - name: Create the virtual environment
+    - name: Create the virtual environment for OpenFisca Web API
       ansible.builtin.command:
         cmd: "python3.11 -m venv {{ venv_path }}"
         creates: "{{ venv_path }}/bin/activate"
@@ -71,7 +71,7 @@
       ansible.builtin.set_fact:
         matomo_enabled: "{{ matomo_site_id and matomo_token and matomo_url }}"
 
-    - name: Install the Python packages
+    - name: Install the OpenFisca Python packages
       loop:
         - { name: "OpenFisca-Core[tracker]", enabled: "{{ matomo_enabled }}" }
         - { name: "OpenFisca-Core[web-api]", enabled: yes }
@@ -85,9 +85,9 @@
         virtualenv_site_packages: no
       become_user: "{{ unix_user_name }}"
 
-- name: Set up the systemd service
+- name: Deploy and manage systemd service for OpenFisca Web API
   block:
-    - name: Create the directory receiving the environment file
+    - name: Create directory for environment configuration file
       ansible.builtin.file:
         path: "{{ env_file | dirname }}"
         state: directory

--- a/ansible/roles/openfisca_api/tasks/main.yml
+++ b/ansible/roles/openfisca_api/tasks/main.yml
@@ -4,7 +4,16 @@
   tags:
     - apt-update-cache
 
-- name: Install Ubuntu packages
+- name: Install required Ubuntu packages
+  ansible.builtin.apt:
+    install_recommends: no
+    name:
+      - acl # Provides "setfacl" command, used by Ansible to become another Unix user
+      - gcc
+    state: present
+    update_cache: no
+
+- name: Install and configure Python environment
   block:
     - name: Enable installing Personal Package Archives (PPA) with apt
       ansible.builtin.apt:
@@ -23,8 +32,6 @@
       ansible.builtin.apt:
         install_recommends: no
         name:
-          - acl # Provides "setfacl" command, used by Ansible to become another Unix user
-          - gcc
           - python3.11-dev # `python3.11-dev` is needed to install OpenFisca because it includes the Python C API headers required for compilation, `python3.11` would not suffice as it lacks these development tools.
           - python3.11-venv # Ensure both `ensurepip` and `venv` modules are available
           - python3-apt

--- a/ansible/roles/openfisca_api/tasks/main.yml
+++ b/ansible/roles/openfisca_api/tasks/main.yml
@@ -25,7 +25,6 @@
         name:
           - acl # Provides "setfacl" command, used by Ansible to become another Unix user
           - gcc
-          - python3.11
           - python3.11-dev # `python3.11-dev` is needed to install OpenFisca because it includes the Python C API headers required for compilation, `python3.11` would not suffice as it lacks these development tools.
           - python3.11-venv # Ensure both `ensurepip` and `venv` modules are available
           - python3-apt

--- a/ansible/roles/openfisca_api/tasks/main.yml
+++ b/ansible/roles/openfisca_api/tasks/main.yml
@@ -109,7 +109,7 @@
     status_code: 300
     timeout: 120
     url: "http://{{ app_host }}:{{ app_port }}"
-  register: this
-  until: this.status == 300
+  register: response
+  until: response.status == 300
   retries: 5 # times
   delay: 5 # seconds

--- a/ansible/roles/openfisca_api/tasks/main.yml
+++ b/ansible/roles/openfisca_api/tasks/main.yml
@@ -1,122 +1,17 @@
-- name: Update the cache of Ubuntu packages
-  ansible.builtin.apt:
-    update_cache: yes
-  tags:
-    - apt-update-cache
-
-- name: Install required Ubuntu packages
-  ansible.builtin.apt:
-    install_recommends: no
-    name:
-      - acl # Provides "setfacl" command, used by Ansible to become another Unix user
-      - gcc
-    state: present
-    update_cache: no
+- name: Update and install system packages
+  include_tasks: packages.yml
 
 - name: Install and configure Python environment
-  block:
-    - name: Enable installing Personal Package Archives (PPA) with apt
-      ansible.builtin.apt:
-        install_recommends: no
-        name:
-          - gnupg
-        state: present
-        update_cache: no
-
-    - name: Enable installing arbitrary Python versions
-      ansible.builtin.apt_repository:
-        repo: ppa:deadsnakes/ppa # See more on https://tooling.bennuttall.com/deadsnakes/
-        state: present
-
-    - name: Install the OpenFisca-supported Python version # See https://github.com/openfisca/openfisca-core#environment
-      ansible.builtin.apt:
-        install_recommends: no
-        name:
-          - python3.11-dev # `python3.11-dev` is needed to install OpenFisca because it includes the Python C API headers required for compilation, `python3.11` would not suffice as it lacks these development tools.
-          - python3.11-venv # Ensure both `ensurepip` and `venv` modules are available
-          - python3-apt
-        state: present
-        update_cache: no
-
-    - name: Install pip
-      ansible.builtin.command: /usr/bin/python3.11 -m ensurepip
+  include_tasks: python_setup.yml
 
 - name: Create Unix group and user for OpenFisca Web API
-  block:
-    - name: Create Unix group for OpenFisca Web API
-      ansible.builtin.group:
-        name: "{{ unix_group_name }}"
-        state: present
+  include_tasks: user_setup.yml
 
-    - name: Create Unix user for OpenFisca Web API
-      ansible.builtin.user:
-        name: "{{ unix_user_name }}"
-        group: "{{ unix_group_name }}"
-        shell: /bin/bash
-      register: unix_user
-
-- name: Install the latest version of OpenFisca Web API in the virtualenv with {{ country_package }}
-  block:
-    - name: Define the virtual environment directory for OpenFisca Web API
-      ansible.builtin.set_fact:
-        venv_path: "{{ unix_user.home }}/{{ venv_dir }}"
-
-    - name: Create the virtual environment for OpenFisca Web API
-      ansible.builtin.command:
-        cmd: "python3.11 -m venv {{ venv_path }}"
-        creates: "{{ venv_path }}/bin/activate"
-      become_user: "{{ unix_user_name }}"
-
-    - name: Determine if Matomo is enabled according to role variables
-      ansible.builtin.set_fact:
-        matomo_enabled: "{{ matomo_site_id and matomo_token and matomo_url }}"
-
-    - name: Install the OpenFisca Python packages
-      loop:
-        - { name: "OpenFisca-Core[tracker]", enabled: "{{ matomo_enabled }}" }
-        - { name: "OpenFisca-Core[web-api]", enabled: yes }
-        - { name: "{{ country_package }}", enabled: yes }
-      when: item.enabled
-      ansible.builtin.pip:
-        name: "{{ item.name }}"
-        state: latest
-        virtualenv: "{{ venv_path }}"
-        virtualenv_python: python3.11
-        virtualenv_site_packages: no
-      become_user: "{{ unix_user_name }}"
+- name: Setup and configure OpenFisca Web API
+  include_tasks: web_api_setup.yml
 
 - name: Deploy and manage systemd service for OpenFisca Web API
-  block:
-    - name: Create directory for environment configuration file
-      ansible.builtin.file:
-        path: "{{ env_file | dirname }}"
-        state: directory
-        mode: "0755"
-
-    - name: Copy the environment file referenced by the systemd service
-      ansible.builtin.template:
-        src: openfisca-web-api.env.j2
-        dest: "{{ env_file }}"
-
-    - name: Copy the systemd service file
-      ansible.builtin.template:
-        src: openfisca-web-api.service.j2
-        dest: "/etc/systemd/system/{{ systemd_service_file_name }}"
-
-    - name: Enable and start the systemd service
-      ansible.builtin.systemd:
-        daemon_reload: yes
-        enabled: yes
-        state: restarted
-        name: "{{ systemd_service_file_name }}"
+  include_tasks: systemd.yml
 
 - name: Check that OpenFisca Web API is actually started
-  ansible.builtin.uri:
-    return_content: yes
-    status_code: 300
-    timeout: 120
-    url: "http://{{ app_host }}:{{ app_port }}"
-  register: response
-  until: response.status == 300
-  retries: 5 # times
-  delay: 5 # seconds
+  include_tasks: health_check.yml

--- a/ansible/roles/openfisca_api/tasks/packages.yml
+++ b/ansible/roles/openfisca_api/tasks/packages.yml
@@ -10,5 +10,6 @@
     name:
       - acl
       - gcc
+      - python3-apt
     state: present
     update_cache: no

--- a/ansible/roles/openfisca_api/tasks/packages.yml
+++ b/ansible/roles/openfisca_api/tasks/packages.yml
@@ -1,0 +1,14 @@
+- name: Update the cache of Ubuntu packages
+  ansible.builtin.apt:
+    update_cache: yes
+  tags:
+    - apt-update-cache
+
+- name: Install required Ubuntu packages
+  ansible.builtin.apt:
+    install_recommends: no
+    name:
+      - acl
+      - gcc
+    state: present
+    update_cache: no

--- a/ansible/roles/openfisca_api/tasks/python_setup.yml
+++ b/ansible/roles/openfisca_api/tasks/python_setup.yml
@@ -11,15 +11,15 @@
     repo: ppa:deadsnakes/ppa
     state: present
 
-- name: Install Python 3.11 for OpenFisca
+- name: Install Python {{ python_version }} for OpenFisca
   ansible.builtin.apt:
     install_recommends: no
     name:
-      - python3.11-dev
-      - python3.11-venv
+      - python{{ python_version }}-dev
+      - python{{ python_version }}-venv
       - python3-apt
     state: present
     update_cache: no
 
 - name: Install pip
-  ansible.builtin.command: /usr/bin/python3.11 -m ensurepip
+  ansible.builtin.command: /usr/bin/python{{ python_version }} -m ensurepip

--- a/ansible/roles/openfisca_api/tasks/python_setup.yml
+++ b/ansible/roles/openfisca_api/tasks/python_setup.yml
@@ -1,0 +1,25 @@
+- name: Enable installing Personal Package Archives (PPA) with apt
+  ansible.builtin.apt:
+    install_recommends: no
+    name:
+      - gnupg
+    state: present
+    update_cache: no
+
+- name: Enable installing arbitrary Python versions
+  ansible.builtin.apt_repository:
+    repo: ppa:deadsnakes/ppa
+    state: present
+
+- name: Install Python 3.11 for OpenFisca
+  ansible.builtin.apt:
+    install_recommends: no
+    name:
+      - python3.11-dev
+      - python3.11-venv
+      - python3-apt
+    state: present
+    update_cache: no
+
+- name: Install pip
+  ansible.builtin.command: /usr/bin/python3.11 -m ensurepip

--- a/ansible/roles/openfisca_api/tasks/python_setup.yml
+++ b/ansible/roles/openfisca_api/tasks/python_setup.yml
@@ -17,7 +17,6 @@
     name:
       - python{{ python_version }}-dev
       - python{{ python_version }}-venv
-      - python3-apt
     state: present
     update_cache: no
 

--- a/ansible/roles/openfisca_api/tasks/systemd.yml
+++ b/ansible/roles/openfisca_api/tasks/systemd.yml
@@ -1,0 +1,22 @@
+- name: Create directory for environment configuration file
+  ansible.builtin.file:
+    path: "{{ env_file | dirname }}"
+    state: directory
+    mode: "0755"
+
+- name: Copy the environment file referenced by the systemd service
+  ansible.builtin.template:
+    src: openfisca-web-api.env.j2
+    dest: "{{ env_file }}"
+
+- name: Copy the systemd service file
+  ansible.builtin.template:
+    src: openfisca-web-api.service.j2
+    dest: "/etc/systemd/system/{{ systemd_service_file_name }}"
+
+- name: Enable and start the systemd service
+  ansible.builtin.systemd:
+    daemon_reload: yes
+    enabled: yes
+    state: restarted
+    name: "{{ systemd_service_file_name }}"

--- a/ansible/roles/openfisca_api/tasks/user_setup.yml
+++ b/ansible/roles/openfisca_api/tasks/user_setup.yml
@@ -1,0 +1,11 @@
+- name: Create Unix group for OpenFisca Web API
+  ansible.builtin.group:
+    name: "{{ unix_group_name }}"
+    state: present
+
+- name: Create Unix user for OpenFisca Web API
+  ansible.builtin.user:
+    name: "{{ unix_user_name }}"
+    group: "{{ unix_group_name }}"
+    shell: /bin/bash
+  register: unix_user

--- a/ansible/roles/openfisca_api/tasks/web_api_setup.yml
+++ b/ansible/roles/openfisca_api/tasks/web_api_setup.yml
@@ -4,7 +4,7 @@
 
 - name: Create the virtual environment for OpenFisca Web API
   ansible.builtin.command:
-    cmd: "python3.11 -m venv {{ venv_path }}"
+    cmd: "python{{ python_version }} -m venv {{ venv_path }}"
     creates: "{{ venv_path }}/bin/activate"
   become_user: "{{ unix_user_name }}"
 
@@ -22,6 +22,6 @@
     name: "{{ item.name }}"
     state: latest
     virtualenv: "{{ venv_path }}"
-    virtualenv_python: python3.11
+    virtualenv_python: "python{{ python_version }}"
     virtualenv_site_packages: no
   become_user: "{{ unix_user_name }}"

--- a/ansible/roles/openfisca_api/tasks/web_api_setup.yml
+++ b/ansible/roles/openfisca_api/tasks/web_api_setup.yml
@@ -1,0 +1,27 @@
+- name: Define the virtual environment directory for OpenFisca Web API
+  ansible.builtin.set_fact:
+    venv_path: "{{ unix_user.home }}/{{ venv_dir }}"
+
+- name: Create the virtual environment for OpenFisca Web API
+  ansible.builtin.command:
+    cmd: "python3.11 -m venv {{ venv_path }}"
+    creates: "{{ venv_path }}/bin/activate"
+  become_user: "{{ unix_user_name }}"
+
+- name: Determine if Matomo is enabled according to role variables
+  ansible.builtin.set_fact:
+    matomo_enabled: "{{ matomo_site_id and matomo_token and matomo_url }}"
+
+- name: Install the OpenFisca Python packages
+  loop:
+    - { name: "OpenFisca-Core[tracker]", enabled: "{{ matomo_enabled }}" }
+    - { name: "OpenFisca-Core[web-api]", enabled: yes }
+    - { name: "{{ country_package }}", enabled: yes }
+  when: item.enabled
+  ansible.builtin.pip:
+    name: "{{ item.name }}"
+    state: latest
+    virtualenv: "{{ venv_path }}"
+    virtualenv_python: python3.11
+    virtualenv_site_packages: no
+  become_user: "{{ unix_user_name }}"

--- a/ansible/roles/openfisca_api/tasks/web_api_setup.yml
+++ b/ansible/roles/openfisca_api/tasks/web_api_setup.yml
@@ -2,10 +2,26 @@
   ansible.builtin.set_fact:
     venv_path: "{{ unix_user.home }}/{{ venv_dir }}"
 
-- name: Create the virtual environment for OpenFisca Web API
+- name: Check current Python version in the virtual environment
+  ansible.builtin.command:
+    cmd: "{{ venv_path }}/bin/python --version"
+  register: python_version_check
+  ignore_errors: true # tells Ansible to continue if python is not yet installed and the command fails
+  changed_when: false # tells Ansible that this task does not make any changes
+  become_user: "{{ unix_user_name }}"
+
+- name: Remove existing virtual environment if Python version is different
+  ansible.builtin.file:
+    path: "{{ venv_path }}"
+    state: absent
+  when: python_version_check.stdout is not search(python_version)
+  become_user: "{{ unix_user_name }}"
+
+- name: Create the virtual environment with expected Python version if needed
   ansible.builtin.command:
     cmd: "python{{ python_version }} -m venv {{ venv_path }}"
-    creates: "{{ venv_path }}/bin/activate"
+    creates: "{{ venv_path }}/bin/activate" # tells Ansible to not run this task if the file already exists
+  when: python_version_check.stdout is not search(python_version)
   become_user: "{{ unix_user_name }}"
 
 - name: Determine if Matomo is enabled according to role variables


### PR DESCRIPTION
Upgrade the Python version in the OpenFisca virtual environment to `v3.11`, resolving issue #125.

Technical Improvements:
- Update the Vagrantfile to support Docker Desktop version `4.3.0` and above.
- Refactor the main tasks file of the `openfisca_api` role into modular files.
- Improve task names.