### PR TITLE
Fix autoupdate by removing deprecated yaml callback plugin

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,9 +2,3 @@
 
 # Disable Ansible ASCII-art cows
 nocows = 1
-
-# The two following lines allow to have human readable output
-# Use the YAML callback plugin.
-stdout_callback = yaml
-# Use the stdout_callback when running ad-hoc commands.
-bin_ansible_callbacks = true


### PR DESCRIPTION
## Summary
- Remove deprecated `stdout_callback = yaml` and `bin_ansible_callbacks` from `ansible.cfg`
- The `community.general.yaml` callback plugin has been removed in newer versions of ansible-core
- Using the default callback plugin instead resolves the autoupdate failure

## Verification
- The change removes the configuration that references the removed plugin
- Autoupdate should now work with modern ansible-core versions

Fixes: https://github.com/openfisca/openfisca-ops/issues/138
