### PR TITLE
Update Ansible version to 2.20

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,7 @@ guest_port = 8000
 host_port = ENV["PORT"] || 8000
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/focal64"
+  config.vm.box = "bento/ubuntu-24.04"
 
   # Used to refer to this VM from Ansible playbooks.
   config.vm.define "openfisca_api"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,17 +11,6 @@ Vagrant.configure("2") do |config|
 
   config.vm.provider :virtualbox
 
-  # Provider for Docker, necessary for Apple Silicon
-  config.vm.provider :docker do |docker, override|
-    override.vm.box = nil
-    docker.image = "rofrano/vagrant-provider:ubuntu"
-    docker.remains_running = true
-    docker.has_ssh = true
-    docker.privileged = true
-    docker.volumes = ["/sys/fs/cgroup:/sys/fs/cgroup:rw"]
-    docker.create_args = ["--cgroupns=host"]
-  end
-
   config.vm.provision :ansible, run: "always" do |ansible|
     ansible.compatibility_mode = "2.0"
     ansible.playbook = "ansible/site.yml"

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -6,3 +6,4 @@ nocows = 1
 # The two following lines allow to have human readable output
 callback_format_pretty = true
 callback_result_format = yaml
+display_failed_stderr = true

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -4,7 +4,5 @@
 nocows = 1
 
 # The two following lines allow to have human readable output
-# Use the YAML callback plugin.
-stdout_callback = yaml
-# Use the stdout_callback when running ad-hoc commands.
-bin_ansible_callbacks = true
+callback_format_pretty = true
+callback_result_format = yaml

--- a/ansible/roles/autoupdate/tasks/main.yml
+++ b/ansible/roles/autoupdate/tasks/main.yml
@@ -1,7 +1,7 @@
 - name: Set up auto-update
   tags:
     - auto-update
-  when: autoupdate_inventory_file
+  when: autoupdate_inventory_file is string
   block:
     - name: Add the "ansible" PPA
       ansible.builtin.apt_repository:

--- a/ansible/roles/openfisca_api/tasks/web_api_setup.yml
+++ b/ansible/roles/openfisca_api/tasks/web_api_setup.yml
@@ -26,7 +26,7 @@
 
 - name: Determine if Matomo is enabled according to role variables
   ansible.builtin.set_fact:
-    matomo_enabled: "{{ matomo_site_id and matomo_token and matomo_url }}"
+    matomo_enabled: "{{ matomo_site_id is string and matomo_token is string and matomo_url is string }}"
 
 - name: Install the OpenFisca Python packages
   loop:

--- a/ansible/roles/reverse_proxy/tasks/main.yml
+++ b/ansible/roles/reverse_proxy/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: Install the reverse-proxy
-  when: reverse_proxy_host_name
+  when: reverse_proxy_host_name is string
   block:
     - name: Install the Nginx Ubuntu package
       ansible.builtin.apt:
@@ -22,7 +22,7 @@
       notify: Reload nginx
 
     - name: Set SSL up
-      when: letsencrypt_email
+      when: letsencrypt_email is string
       block:
         - name: Install Certbot and its Nginx plugin
           ansible.builtin.apt:

--- a/guides/Install-API-instance.md
+++ b/guides/Install-API-instance.md
@@ -12,7 +12,7 @@ That instance of the API will serve by default the [Country Template](https://gi
 
 Rent a server from any commercial provider, choosing a machine that:
 
-- Runs `Ubuntu 20.04`, `Ubuntu 22.04` or `Ubuntu 24.04` as operating system. (Note: `24.10` is not supported at the time of writing because of the [deadsnakes](https://github.com/deadsnakes/) PPA).
+- Runs `Ubuntu 22.04` or `Ubuntu 24.04` as operating system (`<21` is not supported because Python 3.9+ is needed; `24.10` is not supported at the time of writing because of the [deadsnakes](https://github.com/deadsnakes/) PPA).
 - Allows logging in as superuser (administrator) over SSH.
 - Can download packages over the internet.
 

--- a/guides/Serve-local-API.md
+++ b/guides/Serve-local-API.md
@@ -10,13 +10,16 @@ That instance of the API will serve by default the [Country Template](https://gi
 
 In order to isolate the OpenFisca Web API environment from your environment, we will set it up in a [virtual machine](https://en.wikipedia.org/wiki/Virtual_machine).
 
-If you don’t already have a [provider](https://www.vagrantup.com/docs/providers) installed (VirtualBox, Docker, VMWare, Hyper-V…), [install VirtualBox](https://www.virtualbox.org/manual/ch02.html).
+If you don’t already have a [provider](https://www.vagrantup.com/docs/providers) installed (VirtualBox, Docker, VMWare, Hyper-V…) and are not using recent macOS hardware, [install VirtualBox](https://www.virtualbox.org/manual/ch02.html).
 
 ### On a Mac with an Apple Silicon processor
 
-VirtualBox is not compatible with Apple Silicon (M1…) processors. You will thus need to use the Docker provider.
+VirtualBox is not compatible with Apple Silicon (M1, M2…) processors. You will thus need to use the [UTM](https://mac.getutm.app) provider.
 
-To that end, install Docker Desktop through a [manual install](https://docs.docker.com/docker-for-mac/install/) or with `brew install --cask docker`.
+To that end:
+
+1. Install UTM through a [manual install](https://mac.getutm.app) or with `brew install utm`.
+2. Install the [UTM Vagrant provider](https://naveenrajm7.github.io/vagrant_utm/).
 
 ## 2. Set up Vagrant
 
@@ -41,9 +44,9 @@ ansible [core 2.20.6]
 
 1. Clone (or download) the `openfisca-ops` repository: `https://github.com/openfisca/openfisca-ops.git`.
 2. Navigate to the freshly downloaded folder: `cd openfisca-ops`.
-3. Type the following command: `vagrant up`. If you’re on an Apple Silicon machine or want to use Docker instead of VirtualBox, type `vagrant up --provider=docker`.
+3. Type the following command: `vagrant up`. If you’re on an Apple Silicon machine, use `vagrant up --provider=utm`.
 
-Once the command is done, you should have a virtual machine running the OpenFisca Web API with the [Country Template](https://github.com/openfisca/country-template).
+Once the command is executed, you should have a virtual machine running the OpenFisca Web API with the [Country Template](https://github.com/openfisca/country-template).
 
 The port of the application inside the virtual machine is forwarded to the port 8000 on your development machine by default. You can thus access that API on your local machine on [`http://localhost:8000/`](http://localhost:8000/).
 

--- a/guides/Serve-local-API.md
+++ b/guides/Serve-local-API.md
@@ -4,7 +4,7 @@ By following this guide, you will be able to access the latest version of the Op
 
 That instance of the API will serve by default the [Country Template](https://github.com/openfisca/country-template), but you will be able to configure it to serve any other available [country package](https://openfisca.org/en/countries/).
 
-> For information, this guide was written with Ansible 2.11.2 running on Python 3.9.4, Vagrant 2.2.16 and VirtualBox 6.1.22.
+> For information, this guide was written with Ansible 2.20.6 running on Python 3.14.5, Vagrant 2.4.9 and UTM 4.7.5.
 
 ## 1. Install a virtual machine provider
 
@@ -33,7 +33,7 @@ To install Ansible, follow [the documentation](https://docs.ansible.com/ansible/
 To check that Ansible is properly installed, run `ansible --version`. You should get something like:
 
 ```
-ansible [core 2.16.5]
+ansible [core 2.20.6]
    …
 ```
 


### PR DESCRIPTION
Also means dropping support for Ubuntu <21, which in turns means switching from Docker provider to UTM for Vagrant on macOS.

Tested in Ansible, tested in production, fixes #138.